### PR TITLE
AssemblyScript backend (-lang asc), faustwasm generateAuxFiles support, and UI/widget C++-parity fixes

### DIFF
--- a/crates/box-ffi/src/lib.rs
+++ b/crates/box-ffi/src/lib.rs
@@ -54,7 +54,7 @@ use tree_ffi::{
 pub use tree_ffi::{SOperator, SType};
 use ui::{
     ControlKind, ControlRange, ControlSpec, UiBuilder, UiProgram, UiProgramBuilder, UiRootOrigin,
-    ordering_key_from_metadata, split_label_metadata,
+    ordering_key_from_label, split_label_metadata,
 };
 
 /// FIR package exported from box/signal handles for backend FFI constructors.
@@ -170,7 +170,7 @@ pub fn signal_only_root_ui(ctx: &BoxContext, module_name: &str) -> UiProgram {
     let mut builder = UiProgramBuilder::new();
     for control in ctx.signal_controls() {
         let (label, metadata) = control_label_and_metadata(ctx, control);
-        let order_key = ordering_key_from_metadata(&metadata);
+        let order_key = ordering_key_from_label(&label, &metadata);
         controls.push(ControlSpec {
             id: control.id,
             kind: control_kind(control.kind),

--- a/crates/codegen/src/backends/asc/mod.rs
+++ b/crates/codegen/src/backends/asc/mod.rs
@@ -39,6 +39,12 @@ pub struct AscOptions {
     pub quad_type_name: String,
     /// AssemblyScript spelling used for FIR `FixedPoint` values.
     pub fixed_type_name: String,
+    /// Optional JSON description embedded as a `getJSON(): string` method.
+    ///
+    /// Mirrors the C++ asc backend, whose `getJSON()` snapshot is what
+    /// downstream tooling (UI/param extraction, impulse runners) parses for
+    /// inputs/outputs and the UI tree.
+    pub json: Option<String>,
 }
 
 impl Default for AscOptions {
@@ -47,6 +53,7 @@ impl Default for AscOptions {
             class_name: Some("mydsp".to_owned()),
             quad_type_name: "f64".to_owned(),
             fixed_type_name: "f32".to_owned(),
+            json: None,
         }
     }
 }
@@ -188,6 +195,14 @@ pub fn generate_asc_module(
         &declared_functions,
         1,
     );
+
+    // JSON snapshot for tooling (UI/param extraction), mirroring the C++ asc
+    // backend's getJSON().
+    if let Some(json) = options.json.as_deref() {
+        let _ = writeln!(out, "    getJSON(): string {{");
+        let _ = writeln!(out, "        return \"{}\";", escape_as_string(json));
+        let _ = writeln!(out, "    }}");
+    }
 
     // ---- declared functions (compute, instance*, etc.) as class methods ----
     emit_section_methods(store, &mut out, options, &class_name, module.functions, 1)?;
@@ -945,6 +960,23 @@ fn block_stores_var(store: &FirStore, block: FirId, name: &str) -> bool {
     items.iter().any(|id| {
         matches!(match_fir(store, *id), FirMatch::StoreVar { name: v, .. } if v == name)
     })
+}
+
+/// Escapes arbitrary text for embedding inside an AssemblyScript double-quoted
+/// string literal (used by the `getJSON()` snapshot).
+fn escape_as_string(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 16);
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            other => out.push(other),
+        }
+    }
+    out
 }
 
 fn trim_float(value: f64) -> String {

--- a/crates/codegen/src/backends/asc/mod.rs
+++ b/crates/codegen/src/backends/asc/mod.rs
@@ -1,0 +1,1049 @@
+//! AssemblyScript (`asc`) backend generation from FIR `Module` roots.
+//!
+//! # Source provenance
+//! Mirrors the C++ Faust AssemblyScript backend:
+//! - `compiler/generator/assemblyscript/assemblyscript_instructions.hh`
+//! - `compiler/generator/assemblyscript/assemblyscript_code_container.cpp`
+//!
+//! and follows the same module-first structure as this workspace's `cpp`
+//! backend (`crates/codegen/src/backends/cpp/mod.rs`).
+//!
+//! # Output contract
+//! - Emits `export class <name> { ... }`.
+//! - Instance state is addressed as `this.<field>`; static struct fields as
+//!   `<ClassName>.<field>`.
+//! - Numeric literals are wrapped (`<i32>(n)`, `<f32>(n)`, `<f64>(n)`).
+//! - Arrays are `StaticArray<T>`.
+//! - Standard math maps to `Math.*` / `Mathf.*`.
+//! - UI / soundfile nodes are emitted as comments (parity with the C++ asc
+//!   backend, which lowers them to `// ui ...`).
+//!
+//! # Limitations
+//! Scalar code path only. Unsupported FIR nodes fail fast with
+//! `FRS-CGEN-ASC-0003`.
+
+use std::fmt::Write as _;
+
+use fir::{AccessType, FirBinOp, FirId, FirMatch, FirMathOp, FirStore, FirType, NamedType, match_fir};
+
+use crate::backends::faust_api;
+
+pub const BACKEND_NAME: &str = "asc";
+
+/// AssemblyScript backend options.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AscOptions {
+    /// Optional class name override for the FIR module name.
+    pub class_name: Option<String>,
+    /// AssemblyScript spelling used for FIR `Quad` values (unsupported; kept for parity).
+    pub quad_type_name: String,
+    /// AssemblyScript spelling used for FIR `FixedPoint` values.
+    pub fixed_type_name: String,
+}
+
+impl Default for AscOptions {
+    fn default() -> Self {
+        Self {
+            class_name: Some("mydsp".to_owned()),
+            quad_type_name: "f64".to_owned(),
+            fixed_type_name: "f32".to_owned(),
+        }
+    }
+}
+
+/// Stable backend error codes for AssemblyScript code generation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CodegenErrorCode {
+    /// Root FIR node is not a module (`FirMatch::Module`).
+    RootNotModule,
+    /// Module section is not a FIR block shape.
+    InvalidModuleSection,
+    /// One FIR node is not yet supported by the asc emitter.
+    UnsupportedNode,
+}
+
+impl CodegenErrorCode {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::RootNotModule => "FRS-CGEN-ASC-0001",
+            Self::InvalidModuleSection => "FRS-CGEN-ASC-0002",
+            Self::UnsupportedNode => "FRS-CGEN-ASC-0003",
+        }
+    }
+}
+
+/// Typed backend error returned by the asc emitter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodegenError {
+    code: CodegenErrorCode,
+    message: String,
+}
+
+impl CodegenError {
+    #[must_use]
+    pub fn new(code: CodegenErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn code(&self) -> CodegenErrorCode {
+        self.code
+    }
+}
+
+impl std::fmt::Display for CodegenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}] {}", self.code.as_str(), self.message)
+    }
+}
+
+impl std::error::Error for CodegenError {}
+
+/// Decoded FIR module header used by the text emitter.
+#[derive(Debug, Clone)]
+struct ModuleView {
+    name: String,
+    dsp_struct: FirId,
+    globals: FirId,
+    functions: FirId,
+    num_inputs: usize,
+    num_outputs: usize,
+    static_decls: FirId,
+}
+
+/// Borrowed function declaration view used while stitching the class body.
+struct DeclareFunView<'a> {
+    name: &'a str,
+    typ: &'a FirType,
+    named_args: &'a [NamedType],
+    body: Option<FirId>,
+}
+
+/// Where a declaration is being emitted. Controls `let` vs class-field form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Phase {
+    /// Inside the class field section: emit `name: type` members.
+    Fields,
+    /// Inside a method/function body: emit `let name: type` locals.
+    Body,
+}
+
+/// Float type used for `FaustFloat` (the asc backend is single-precision).
+const FAUST_FLOAT: &str = "f32";
+
+/// Generates AssemblyScript code from a FIR module root.
+///
+/// # Errors
+/// Returns [`CodegenError`] with code `FRS-CGEN-ASC-0001` when `module`
+/// does not decode to `FirMatch::Module`.
+pub fn generate_asc_module(
+    store: &FirStore,
+    module: FirId,
+    options: &AscOptions,
+) -> Result<String, CodegenError> {
+    let module = decode_module(store, module)?;
+    let class_name = options
+        .class_name
+        .as_deref()
+        .unwrap_or(module.name.as_str())
+        .to_owned();
+    let declared_functions = collect_module_function_names(store, module.functions)?;
+
+    let mut out = String::new();
+    let _ = writeln!(out, "// Code generated with faust-rs (https://faust.grame.fr)");
+    let _ = writeln!(out, "// Language: AssemblyScript (experimental)");
+    let _ = writeln!(out, "// name: {}", module.name);
+    let _ = writeln!(out);
+
+    // Top-level helper functions (non-DSP-API DeclareFun in the globals section)
+    // are emitted as module-level `export function`s before the class.
+    emit_toplevel_functions(store, &mut out, options, &class_name, module.globals)?;
+
+    // Compile-time constant tables become module-level `const`s.
+    emit_static_tables(store, &mut out, options, module.static_decls)?;
+
+    let _ = writeln!(out, "export class {class_name} {{");
+
+    // ---- fields: DSP struct state + globals (non-function) ----
+    if !block_declares_var(store, module.dsp_struct, "fSampleRate")
+        && !block_declares_var(store, module.globals, "fSampleRate")
+    {
+        let _ = writeln!(out, "    fSampleRate: i32 = 0;");
+    }
+    emit_section_fields(store, &mut out, options, &class_name, module.dsp_struct, 1)?;
+    emit_section_fields(store, &mut out, options, &class_name, module.globals, 1)?;
+    let _ = writeln!(out);
+
+    // ---- DSP API methods ----
+    emit_dsp_contract_methods(
+        &mut out,
+        module.num_inputs,
+        module.num_outputs,
+        &class_name,
+        &module.name,
+        &declared_functions,
+        1,
+    );
+
+    // ---- declared functions (compute, instance*, etc.) as class methods ----
+    emit_section_methods(store, &mut out, options, &class_name, module.functions, 1)?;
+
+    let _ = writeln!(out, "}}");
+    Ok(out)
+}
+
+/// Emits module-level helper functions found in the globals section.
+fn emit_toplevel_functions(
+    store: &FirStore,
+    out: &mut String,
+    options: &AscOptions,
+    class_name: &str,
+    globals: FirId,
+) -> Result<(), CodegenError> {
+    let FirMatch::Block(items) = match_fir(store, globals) else {
+        return Ok(());
+    };
+    let mut any = false;
+    for item in items {
+        if let FirMatch::DeclareFun {
+            name, typ, args, body, ..
+        } = match_fir(store, item)
+        {
+            // Only real definitions (with a body) become top-level functions.
+            if body.is_none() {
+                continue;
+            }
+            emit_declare_fun(
+                store,
+                out,
+                options,
+                class_name,
+                DeclareFunView {
+                    name: &name,
+                    typ: &typ,
+                    named_args: &args,
+                    body,
+                },
+                0,
+                /* as_method = */ false,
+            )?;
+            any = true;
+        }
+    }
+    if any {
+        let _ = writeln!(out);
+    }
+    Ok(())
+}
+
+/// Emits the standard Faust DSP API surface in AssemblyScript form, synthesizing
+/// any methods the FIR module did not declare itself.
+fn emit_dsp_contract_methods(
+    out: &mut String,
+    num_inputs: usize,
+    num_outputs: usize,
+    class_name: &str,
+    module_name: &str,
+    declared: &[String],
+    indent: usize,
+) {
+    let tab = "    ".repeat(indent);
+    let has = |n: &str| declared.iter().any(|d| d == n);
+
+    let _ = writeln!(out, "{tab}getNumInputs(): i32 {{ return {num_inputs}; }}");
+    let _ = writeln!(out, "{tab}getNumOutputs(): i32 {{ return {num_outputs}; }}");
+    let _ = writeln!(out, "{tab}getSampleRate(): i32 {{ return this.fSampleRate; }}");
+    let _ = writeln!(out, "{tab}static classInit(sample_rate: i32): void {{}}");
+
+    if !has("instanceConstants") {
+        let _ = writeln!(out, "{tab}instanceConstants(sample_rate: i32): void {{");
+        let _ = writeln!(out, "{tab}    this.fSampleRate = sample_rate;");
+        let _ = writeln!(out, "{tab}}}");
+    }
+    if !has("instanceResetUserInterface") {
+        let _ = writeln!(out, "{tab}instanceResetUserInterface(): void {{}}");
+    }
+    if !has("instanceClear") {
+        let _ = writeln!(out, "{tab}instanceClear(): void {{}}");
+    }
+    let _ = writeln!(out, "{tab}instanceInit(sample_rate: i32): void {{");
+    let _ = writeln!(out, "{tab}    this.instanceConstants(sample_rate);");
+    let _ = writeln!(out, "{tab}    this.instanceResetUserInterface();");
+    let _ = writeln!(out, "{tab}    this.instanceClear();");
+    let _ = writeln!(out, "{tab}}}");
+    let _ = writeln!(out, "{tab}init(sample_rate: i32): void {{");
+    let _ = writeln!(out, "{tab}    {class_name}.classInit(sample_rate);");
+    let _ = writeln!(out, "{tab}    this.instanceInit(sample_rate);");
+    let _ = writeln!(out, "{tab}}}");
+    if !has("metadata") {
+        let _ = writeln!(out, "{tab}// metadata: name {module_name}");
+    }
+    if !has("buildUserInterface") {
+        let _ = writeln!(out, "{tab}// ui openbox {module_name}");
+    }
+    if !has("compute") {
+        let _ = writeln!(
+            out,
+            "{tab}compute(count: i32, inputs: Array<Array<{FAUST_FLOAT}>>, outputs: Array<Array<{FAUST_FLOAT}>>): void {{}}"
+        );
+    }
+}
+
+/// Collects declared function names to decide which DSP API stubs to synthesize.
+fn collect_module_function_names(
+    store: &FirStore,
+    functions: FirId,
+) -> Result<Vec<String>, CodegenError> {
+    let FirMatch::Block(items) = match_fir(store, functions) else {
+        return Err(invalid_section("functions", functions, store));
+    };
+    let mut names = Vec::new();
+    for item in items {
+        if let FirMatch::DeclareFun { name, .. } = match_fir(store, item) {
+            names.push(name);
+        }
+    }
+    Ok(names)
+}
+
+/// Emits a module section as class fields (`DeclareVar` only).
+fn emit_section_fields(
+    store: &FirStore,
+    out: &mut String,
+    options: &AscOptions,
+    class_name: &str,
+    section_id: FirId,
+    indent: usize,
+) -> Result<(), CodegenError> {
+    let FirMatch::Block(items) = match_fir(store, section_id) else {
+        return Err(invalid_section("fields", section_id, store));
+    };
+    for item in items {
+        match match_fir(store, item) {
+            FirMatch::DeclareVar { .. } | FirMatch::DeclareTable { .. } => {
+                emit_stmt(store, out, options, class_name, item, indent, Phase::Fields)?;
+            }
+            // functions / struct-type decls are emitted elsewhere or ignored here
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// Emits a module section as class methods (`DeclareFun` only).
+fn emit_section_methods(
+    store: &FirStore,
+    out: &mut String,
+    options: &AscOptions,
+    class_name: &str,
+    section_id: FirId,
+    indent: usize,
+) -> Result<(), CodegenError> {
+    let FirMatch::Block(items) = match_fir(store, section_id) else {
+        return Err(invalid_section("functions", section_id, store));
+    };
+    for item in items {
+        if let FirMatch::DeclareFun {
+            name, typ, args, body, ..
+        } = match_fir(store, item)
+        {
+            emit_declare_fun(
+                store,
+                out,
+                options,
+                class_name,
+                DeclareFunView {
+                    name: &name,
+                    typ: &typ,
+                    named_args: &args,
+                    body,
+                },
+                indent,
+                /* as_method = */ true,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// Emits one FIR statement.
+fn emit_stmt(
+    store: &FirStore,
+    out: &mut String,
+    options: &AscOptions,
+    class_name: &str,
+    stmt: FirId,
+    indent: usize,
+    phase: Phase,
+) -> Result<(), CodegenError> {
+    let tab = "    ".repeat(indent);
+    match match_fir(store, stmt) {
+        FirMatch::DeclareVar { name, typ, access, init } => {
+            if phase == Phase::Fields {
+                if access == AccessType::Static {
+                    let _ = write!(out, "{tab}static ");
+                } else {
+                    let _ = write!(out, "{tab}");
+                }
+                let _ = write!(out, "{}", emit_member_decl(&typ, &name, options));
+                if let Some(init) = init {
+                    let init = emit_value(store, options, class_name, init)?;
+                    let _ = write!(out, " = {init}");
+                } else if let FirType::Array(inner, size) = &typ
+                    && *size > 0
+                {
+                    let _ = write!(
+                        out,
+                        " = new StaticArray<{}>({size})",
+                        emit_type(inner, options)
+                    );
+                }
+                let _ = writeln!(out, ";");
+            } else {
+                let _ = write!(out, "{tab}let {}: {}", name, emit_type(&typ, options));
+                if let Some(init) = init {
+                    let init = emit_value(store, options, class_name, init)?;
+                    let _ = write!(out, " = {init}");
+                }
+                let _ = writeln!(out, ";");
+            }
+            Ok(())
+        }
+        FirMatch::DeclareTable { name, elem_type, values, access } => {
+            let prefix = if phase == Phase::Fields { "" } else { "let " };
+            let static_kw = if phase == Phase::Fields && access == AccessType::Static {
+                "static "
+            } else {
+                ""
+            };
+            let _ = writeln!(
+                out,
+                "{tab}{static_kw}{prefix}{name}: StaticArray<{}> = new StaticArray<{}>({});",
+                emit_type(&elem_type, options),
+                emit_type(&elem_type, options),
+                values.len()
+            );
+            Ok(())
+        }
+        FirMatch::StoreVar { name, access, value } => {
+            let value = emit_value(store, options, class_name, value)?;
+            let lhs = qualify(&name, access, class_name);
+            let _ = writeln!(out, "{tab}{lhs} = {value};");
+            Ok(())
+        }
+        FirMatch::StoreTable { name, index, value, access } => {
+            let index = emit_value(store, options, class_name, index)?;
+            let value = emit_value(store, options, class_name, value)?;
+            let lhs = qualify(&name, access, class_name);
+            let _ = writeln!(out, "{tab}{lhs}[{index}] = {value};");
+            Ok(())
+        }
+        FirMatch::Drop(value) => {
+            let value = emit_value(store, options, class_name, value)?;
+            let _ = writeln!(out, "{tab}{value};");
+            Ok(())
+        }
+        FirMatch::NullStatement => Ok(()),
+        FirMatch::Return(value) => {
+            if let Some(value) = value {
+                let value = emit_value(store, options, class_name, value)?;
+                let _ = writeln!(out, "{tab}return {value};");
+            } else {
+                let _ = writeln!(out, "{tab}return;");
+            }
+            Ok(())
+        }
+        FirMatch::Block(_) => emit_block(store, out, options, class_name, stmt, indent),
+        FirMatch::If { cond, then_block, else_block } => {
+            let cond = emit_value(store, options, class_name, cond)?;
+            let _ = writeln!(out, "{tab}if ({cond}) {{");
+            emit_block(store, out, options, class_name, then_block, indent + 1)?;
+            let _ = writeln!(out, "{tab}}}");
+            if let Some(else_block) = else_block {
+                let _ = writeln!(out, "{tab}else {{");
+                emit_block(store, out, options, class_name, else_block, indent + 1)?;
+                let _ = writeln!(out, "{tab}}}");
+            }
+            Ok(())
+        }
+        FirMatch::Control { cond, stmt } => {
+            let cond = emit_value(store, options, class_name, cond)?;
+            let _ = writeln!(out, "{tab}if ({cond}) {{");
+            emit_stmt(store, out, options, class_name, stmt, indent + 1, Phase::Body)?;
+            let _ = writeln!(out, "{tab}}}");
+            Ok(())
+        }
+        FirMatch::ForLoop { var, init, end, step, body, is_reverse } => {
+            let init_val =
+                if let FirMatch::DeclareVar { init: Some(v), .. } = match_fir(store, init) {
+                    emit_value(store, options, class_name, v)?
+                } else {
+                    emit_value(store, options, class_name, init)?
+                };
+            let end = emit_value(store, options, class_name, end)?;
+            let step = emit_value(store, options, class_name, step)?;
+            if is_reverse {
+                let _ = writeln!(
+                    out,
+                    "{tab}for (let {var}: i32 = {init_val}; {var} > {end}; {var} = {var} + {step}) {{"
+                );
+            } else {
+                let _ = writeln!(
+                    out,
+                    "{tab}for (let {var}: i32 = {init_val}; {var} < {end}; {var} = {var} + {step}) {{"
+                );
+            }
+            emit_block(store, out, options, class_name, body, indent + 1)?;
+            let _ = writeln!(out, "{tab}}}");
+            Ok(())
+        }
+        FirMatch::SimpleForLoop { var, upper, body, is_reverse } => {
+            let upper = emit_value(store, options, class_name, upper)?;
+            if is_reverse {
+                let _ = writeln!(
+                    out,
+                    "{tab}for (let {var}: i32 = ({upper}) - 1; {var} >= 0; {var} = {var} - 1) {{"
+                );
+            } else {
+                let _ = writeln!(
+                    out,
+                    "{tab}for (let {var}: i32 = 0; {var} < {upper}; {var} = {var} + 1) {{"
+                );
+            }
+            emit_block(store, out, options, class_name, body, indent + 1)?;
+            let _ = writeln!(out, "{tab}}}");
+            Ok(())
+        }
+        FirMatch::IteratorForLoop { iterators, body, .. } => {
+            // The scalar asc path doesn't lower vectorized iterator loops; emit
+            // the body inline (parity with the C++ backend's comment + body).
+            let _ = writeln!(out, "{tab}// iterator-for over [{}]", iterators.join(", "));
+            emit_block(store, out, options, class_name, body, indent)?;
+            Ok(())
+        }
+        FirMatch::WhileLoop { cond, body } => {
+            let cond = emit_value(store, options, class_name, cond)?;
+            let _ = writeln!(out, "{tab}while ({cond}) {{");
+            emit_block(store, out, options, class_name, body, indent + 1)?;
+            let _ = writeln!(out, "{tab}}}");
+            Ok(())
+        }
+        FirMatch::Switch { cond, cases, default } => {
+            let cond = emit_value(store, options, class_name, cond)?;
+            let _ = writeln!(out, "{tab}switch ({cond}) {{");
+            for (value, block) in cases {
+                let _ = writeln!(out, "{tab}case {value}: {{");
+                emit_block(store, out, options, class_name, block, indent + 1)?;
+                let _ = writeln!(out, "{tab}    break;");
+                let _ = writeln!(out, "{tab}}}");
+            }
+            if let Some(default) = default {
+                let _ = writeln!(out, "{tab}default: {{");
+                emit_block(store, out, options, class_name, default, indent + 1)?;
+                let _ = writeln!(out, "{tab}}}");
+            }
+            let _ = writeln!(out, "{tab}}}");
+            Ok(())
+        }
+        // UI / metadata / soundfile lower to comments (parity with C++ asc backend).
+        FirMatch::OpenBox { label, .. } => {
+            let _ = writeln!(out, "{tab}// ui openbox {label}");
+            Ok(())
+        }
+        FirMatch::CloseBox => {
+            let _ = writeln!(out, "{tab}// ui closebox");
+            Ok(())
+        }
+        FirMatch::AddButton { label, .. } => {
+            let _ = writeln!(out, "{tab}// ui button {label}");
+            Ok(())
+        }
+        FirMatch::AddSlider { label, .. } => {
+            let _ = writeln!(out, "{tab}// ui slider {label}");
+            Ok(())
+        }
+        FirMatch::AddBargraph { label, .. } => {
+            let _ = writeln!(out, "{tab}// ui bargraph {label}");
+            Ok(())
+        }
+        FirMatch::AddSoundfile { .. } => {
+            let _ = writeln!(out, "{tab}// ui soundfile unsupported in AssemblyScript backend");
+            Ok(())
+        }
+        FirMatch::AddMetaDeclare { key, .. } => {
+            let _ = writeln!(out, "{tab}// metadata {key}");
+            Ok(())
+        }
+        FirMatch::Label(_) | FirMatch::ShiftArrayVar { .. } | FirMatch::DeclareStructType { .. } => {
+            Ok(())
+        }
+        FirMatch::DeclareBufferIterators {
+            name1, name2, channels, ..
+        } => {
+            // Buffer-iterator hints are a vectorization aid; the scalar asc path
+            // does not use them. Emit a comment for parity with the C++ backend.
+            let _ = writeln!(out, "{tab}// buffer iterators: {name1}, {name2}, channels={channels}");
+            Ok(())
+        }
+        _ => Err(unsupported_node("statement", stmt, store)),
+    }
+}
+
+/// Emits every statement in a FIR block (body phase).
+fn emit_block(
+    store: &FirStore,
+    out: &mut String,
+    options: &AscOptions,
+    class_name: &str,
+    block: FirId,
+    indent: usize,
+) -> Result<(), CodegenError> {
+    let FirMatch::Block(items) = match_fir(store, block) else {
+        return Err(unsupported_node("expected block", block, store));
+    };
+    for stmt in items {
+        emit_stmt(store, out, options, class_name, stmt, indent, Phase::Body)?;
+    }
+    Ok(())
+}
+
+/// Emits one FIR function as a class method or a top-level function.
+fn emit_declare_fun(
+    store: &FirStore,
+    out: &mut String,
+    options: &AscOptions,
+    class_name: &str,
+    decl: DeclareFunView<'_>,
+    indent: usize,
+    as_method: bool,
+) -> Result<(), CodegenError> {
+    faust_api::validate_canonical_dsp_api_signature(decl.name, decl.typ, decl.named_args)
+        .map_err(|msg| CodegenError::new(CodegenErrorCode::InvalidModuleSection, msg))?;
+    let tab = "    ".repeat(indent);
+
+    // For DSP API methods, the FIR carries an explicit leading `dsp` arg; strip it.
+    let strip_dsp_arg = is_dsp_api_method(decl.name)
+        && matches!(decl.named_args.first(), Some(n) if n.name == "dsp");
+
+    let (ret, params) = match decl.typ {
+        FirType::Fun { args, ret } => {
+            let ret = emit_type(ret, options);
+            let skip = usize::from(strip_dsp_arg);
+            let render = &args[skip.min(args.len())..];
+            let mut rendered = Vec::with_capacity(render.len());
+            for (i, arg_ty) in render.iter().enumerate() {
+                let name = decl
+                    .named_args
+                    .get(i + skip)
+                    .map_or_else(|| format!("arg{i}"), |n| n.name.clone());
+                rendered.push(format!("{name}: {}", emit_type(arg_ty, options)));
+            }
+            (ret, rendered.join(", "))
+        }
+        other => (emit_type(other, options), String::new()),
+    };
+
+    // Canonical compute signature override (nested channel arrays).
+    let params = if decl.name == "compute" {
+        format!("count: i32, inputs: Array<Array<{FAUST_FLOAT}>>, outputs: Array<Array<{FAUST_FLOAT}>>")
+    } else {
+        params
+    };
+
+    let Some(body) = decl.body else {
+        // Prototype-only: AssemblyScript has no C-style prototypes, so skip.
+        return Ok(());
+    };
+
+    if as_method {
+        let _ = writeln!(out, "{tab}{}({params}): {ret} {{", decl.name);
+    } else {
+        let _ = writeln!(out, "{tab}export function {}({params}): {ret} {{", decl.name);
+    }
+    if decl.name == "instanceConstants" && !block_stores_var(store, body, "fSampleRate") {
+        let _ = writeln!(out, "{tab}    this.fSampleRate = sample_rate;");
+    }
+    emit_block(store, out, options, class_name, body, indent + 1)?;
+    let _ = writeln!(out, "{tab}}}");
+    Ok(())
+}
+
+/// Emits one FIR value expression into an AssemblyScript expression string.
+fn emit_value(
+    store: &FirStore,
+    options: &AscOptions,
+    class_name: &str,
+    value: FirId,
+) -> Result<String, CodegenError> {
+    match match_fir(store, value) {
+        FirMatch::Int32 { value, .. } => Ok(format!("<i32>({value})")),
+        FirMatch::Int64 { value, .. } => Ok(format!("<i64>({value})")),
+        // Float literals are emitted as bare/generic numbers (not `<f64>(..)`),
+        // so they adapt to the assignment/operand context. AssemblyScript has no
+        // implicit f64->f32 narrowing, and Faust FIR carries signal constants as
+        // Float64 even for single-precision (FaustFloat=f32) DSPs; a forced
+        // `<f64>(..)` would fail to assign to an f32 field.
+        FirMatch::Float32 { value, .. } => Ok(trim_float(f64::from(value))),
+        FirMatch::Float64 { value, .. } => Ok(trim_float(value)),
+        FirMatch::Bool { value, .. } => Ok(if value { "true" } else { "false" }.to_owned()),
+        FirMatch::Quad { value, .. } => Ok(trim_float(value)),
+        FirMatch::FixedPoint { value, .. } => Ok(trim_float(value)),
+        FirMatch::Int32Array { values, .. } => {
+            Ok(format_array(values.iter().map(ToString::to_string)))
+        }
+        FirMatch::Float32Array { values, .. } => Ok(format_array(
+            values.iter().map(|v| trim_float(f64::from(*v))),
+        )),
+        FirMatch::Float64Array { values, .. }
+        | FirMatch::QuadArray { values, .. }
+        | FirMatch::FixedPointArray { values, .. } => {
+            Ok(format_array(values.iter().map(|v| trim_float(*v))))
+        }
+        FirMatch::ValueArray { values, .. } => {
+            let mut rendered = Vec::with_capacity(values.len());
+            for item in values {
+                rendered.push(emit_value(store, options, class_name, item)?);
+            }
+            Ok(format_array(rendered.into_iter()))
+        }
+        FirMatch::LoadVar { name, access, .. } | FirMatch::LoadVarAddress { name, access, .. } => {
+            Ok(qualify(&name, access, class_name))
+        }
+        FirMatch::LoadTable { name, index, access, .. } => {
+            let index = emit_value(store, options, class_name, index)?;
+            Ok(format!("{}[{index}]", qualify(&name, access, class_name)))
+        }
+        FirMatch::TeeVar { name, access, value, .. } => {
+            let value = emit_value(store, options, class_name, value)?;
+            Ok(format!("({} = {value})", qualify(&name, access, class_name)))
+        }
+        FirMatch::BinOp { op, lhs, rhs, .. } => {
+            let lhs = emit_value(store, options, class_name, lhs)?;
+            let rhs = emit_value(store, options, class_name, rhs)?;
+            Ok(format!("({lhs} {} {rhs})", emit_binop(op)))
+        }
+        FirMatch::Neg { value, .. } => {
+            let value = emit_value(store, options, class_name, value)?;
+            Ok(format!("(-{value})"))
+        }
+        FirMatch::Cast { typ, value } | FirMatch::Bitcast { typ, value } => {
+            let value = emit_value(store, options, class_name, value)?;
+            Ok(format!("<{}>({value})", emit_type(&typ, options)))
+        }
+        FirMatch::Select2 { cond, then_value, else_value, .. } => {
+            let cond = emit_value(store, options, class_name, cond)?;
+            let then_value = emit_value(store, options, class_name, then_value)?;
+            let else_value = emit_value(store, options, class_name, else_value)?;
+            Ok(format!("({cond} ? {then_value} : {else_value})"))
+        }
+        FirMatch::FunCall { name, args, .. } => {
+            let mut rendered = Vec::with_capacity(args.len());
+            for arg in args {
+                rendered.push(emit_value(store, options, class_name, arg)?);
+            }
+            Ok(format!("{}({})", map_fun_name(&name), rendered.join(", ")))
+        }
+        FirMatch::NullValue { .. } => Ok("null".to_owned()),
+        FirMatch::NewDsp { name, .. } => Ok(format!("new {name}()")),
+        _ => Err(unsupported_node("value", value, store)),
+    }
+}
+
+/// Qualifies a name with `this.` / `<ClassName>.` based on FIR access kind.
+fn qualify(name: &str, access: AccessType, class_name: &str) -> String {
+    match access {
+        AccessType::Struct => format!("this.{name}"),
+        AccessType::Static => format!("{class_name}.{name}"),
+        _ => name.to_owned(),
+    }
+}
+
+/// Emits a class field declaration `name: type` (arrays become `StaticArray<T>`).
+fn emit_member_decl(typ: &FirType, name: &str, options: &AscOptions) -> String {
+    format!("{name}: {}", emit_type(typ, options))
+}
+
+/// Maps a bare FIR math/function name to the AssemblyScript spelling.
+///
+/// Mirrors the C++ asc backend's `gMathLibTable`: 32-bit (`*f`) intrinsics map to
+/// `Mathf.*`, double versions to `Math.*`, `abs`/`fabs` to `Math.abs`, and the
+/// min/max helpers to AssemblyScript's generic `min<T>`/`max<T>`.
+fn map_fun_name(name: &str) -> String {
+    match name {
+        "abs" | "fabs" => return "Math.abs".to_owned(),
+        "fabsf" => return "Mathf.abs".to_owned(),
+        "min_i" => return "min<i32>".to_owned(),
+        "max_i" => return "max<i32>".to_owned(),
+        // single-precision min/max (Faust `*f` spelling) -> generic f32 helpers
+        "min_f" | "fminf" => return "min<f32>".to_owned(),
+        "max_f" | "fmaxf" => return "max<f32>".to_owned(),
+        // double-precision min/max -> generic f64 helpers
+        "min_" | "fmin" => return "min<f64>".to_owned(),
+        "max_" | "fmax" => return "max<f64>".to_owned(),
+        // fmod has no Math helper; AssemblyScript uses the `%` operator instead,
+        // but as a call site we fall back to the f64/f32 remainder helpers.
+        "fmod" | "fmodf" => return "_fmod".to_owned(),
+        _ => {}
+    }
+    // float (32-bit) intrinsics -> Mathf.*, double -> Math.*
+    if let Some(stripped) = name.strip_suffix('f')
+        && let Some(op) = FirMathOp::from_symbol(stripped)
+    {
+        return format!("Mathf.{}", op.symbol());
+    }
+    if let Some(op) = FirMathOp::from_symbol(name) {
+        return format!("Math.{}", op.symbol());
+    }
+    name.to_owned()
+}
+
+/// Maps one FIR binary operator to its AssemblyScript token spelling.
+fn emit_binop(op: FirBinOp) -> &'static str {
+    match op {
+        FirBinOp::Add => "+",
+        FirBinOp::Sub => "-",
+        FirBinOp::Mul => "*",
+        FirBinOp::Div => "/",
+        FirBinOp::Rem => "%",
+        FirBinOp::And => "&",
+        FirBinOp::Or => "|",
+        FirBinOp::Xor => "^",
+        FirBinOp::Lsh => "<<",
+        FirBinOp::ARsh => ">>",
+        FirBinOp::LRsh => ">>>",
+        FirBinOp::Eq => "==",
+        FirBinOp::Ne => "!=",
+        FirBinOp::Lt => "<",
+        FirBinOp::Le => "<=",
+        FirBinOp::Gt => ">",
+        FirBinOp::Ge => ">=",
+    }
+}
+
+/// Renders a FIR type into AssemblyScript spelling.
+fn emit_type(typ: &FirType, options: &AscOptions) -> String {
+    match typ {
+        FirType::Int32 => "i32".to_owned(),
+        FirType::Int64 => "i64".to_owned(),
+        FirType::Float32 => "f32".to_owned(),
+        FirType::Float64 => "f64".to_owned(),
+        FirType::FaustFloat => FAUST_FLOAT.to_owned(),
+        FirType::Quad => options.quad_type_name.clone(),
+        FirType::FixedPoint => options.fixed_type_name.clone(),
+        FirType::Bool => "bool".to_owned(),
+        FirType::Void => "void".to_owned(),
+        FirType::Obj => "usize".to_owned(),
+        FirType::Sound => "usize".to_owned(),
+        FirType::UI => "usize".to_owned(),
+        FirType::Meta => "usize".to_owned(),
+        FirType::Ptr(inner) => format!("StaticArray<{}>", emit_type(inner, options)),
+        FirType::Array(inner, _size) => format!("StaticArray<{}>", emit_type(inner, options)),
+        FirType::Vector(inner, _lanes) => format!("StaticArray<{}>", emit_type(inner, options)),
+        FirType::Struct(name, _fields) => name.clone(),
+        FirType::Fun { .. } => "usize".to_owned(),
+    }
+}
+
+/// Emits `DeclareTable(Static)` nodes as module-level `const` StaticArrays.
+fn emit_static_tables(
+    store: &FirStore,
+    out: &mut String,
+    options: &AscOptions,
+    block: FirId,
+) -> Result<(), CodegenError> {
+    let FirMatch::Block(stmts) = match_fir(store, block) else {
+        return Ok(());
+    };
+    let mut any = false;
+    for stmt in stmts {
+        if let FirMatch::DeclareTable { name, elem_type, values, .. } = match_fir(store, stmt) {
+            let ty = emit_type(&elem_type, options);
+            if values.is_empty() {
+                let _ = writeln!(
+                    out,
+                    "const {name}: StaticArray<{ty}> = new StaticArray<{ty}>(0);"
+                );
+            } else {
+                let mut elems = Vec::with_capacity(values.len());
+                for v in &values {
+                    elems.push(emit_value(store, options, "", *v)?);
+                }
+                let _ = writeln!(
+                    out,
+                    "const {name}: StaticArray<{ty}> = StaticArray.fromArray<{ty}>([{}]);",
+                    elems.join(", ")
+                );
+            }
+            any = true;
+        }
+    }
+    if any {
+        let _ = writeln!(out);
+    }
+    Ok(())
+}
+
+fn decode_module(store: &FirStore, module: FirId) -> Result<ModuleView, CodegenError> {
+    match match_fir(store, module) {
+        FirMatch::Module {
+            num_inputs,
+            num_outputs,
+            name,
+            dsp_struct,
+            globals,
+            functions,
+            static_decls,
+        } => Ok(ModuleView {
+            name,
+            dsp_struct,
+            globals,
+            functions,
+            num_inputs,
+            num_outputs,
+            static_decls,
+        }),
+        _ => Err(CodegenError::new(
+            CodegenErrorCode::RootNotModule,
+            format!(
+                "expected FIR module root, got {:?} at node {}",
+                match_fir(store, module),
+                module.as_u32()
+            ),
+        )),
+    }
+}
+
+fn is_dsp_api_method(name: &str) -> bool {
+    matches!(
+        name,
+        "metadata"
+            | "instanceConstants"
+            | "instanceResetUserInterface"
+            | "instanceClear"
+            | "buildUserInterface"
+            | "compute"
+    )
+}
+
+fn block_declares_var(store: &FirStore, block: FirId, name: &str) -> bool {
+    let FirMatch::Block(items) = match_fir(store, block) else {
+        return false;
+    };
+    items.iter().any(|id| {
+        matches!(match_fir(store, *id), FirMatch::DeclareVar { name: v, .. } if v == name)
+    })
+}
+
+fn block_stores_var(store: &FirStore, block: FirId, name: &str) -> bool {
+    let FirMatch::Block(items) = match_fir(store, block) else {
+        return false;
+    };
+    items.iter().any(|id| {
+        matches!(match_fir(store, *id), FirMatch::StoreVar { name: v, .. } if v == name)
+    })
+}
+
+fn trim_float(value: f64) -> String {
+    let mut text = format!("{value}");
+    if !text.contains(['.', 'e', 'E']) {
+        text.push_str(".0");
+    }
+    text
+}
+
+fn format_array(values: impl Iterator<Item = String>) -> String {
+    format!("[{}]", values.collect::<Vec<_>>().join(", "))
+}
+
+fn invalid_section(section: &str, id: FirId, store: &FirStore) -> CodegenError {
+    CodegenError::new(
+        CodegenErrorCode::InvalidModuleSection,
+        format!(
+            "section '{section}' must be a FIR block, got {:?} at node {}",
+            match_fir(store, id),
+            id.as_u32()
+        ),
+    )
+}
+
+fn unsupported_node(kind: &str, node: FirId, store: &FirStore) -> CodegenError {
+    CodegenError::new(
+        CodegenErrorCode::UnsupportedNode,
+        format!(
+            "unsupported FIR {kind} node {:?} at {}",
+            match_fir(store, node),
+            node.as_u32()
+        ),
+    )
+}
+
+#[must_use]
+pub fn backend_id() -> &'static str {
+    BACKEND_NAME
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fir::FirBuilder;
+
+    #[test]
+    fn rejects_non_module_root() {
+        let mut store = FirStore::new();
+        let mut b = FirBuilder::new(&mut store);
+        let not_module = b.int32(7);
+        let err = generate_asc_module(&store, not_module, &AscOptions::default())
+            .expect_err("non-module root must fail");
+        assert_eq!(err.code(), CodegenErrorCode::RootNotModule);
+        assert!(err.to_string().contains("FRS-CGEN-ASC-0001"));
+    }
+
+    #[test]
+    fn accepts_minimal_module() {
+        let mut store = FirStore::new();
+        let mut b = FirBuilder::new(&mut store);
+        let dsp_struct = b.block(&[]);
+        let globals = b.block(&[]);
+        let functions = b.block(&[]);
+        let static_decls = b.block(&[]);
+        let module = b.module(1, 2, "mydsp", dsp_struct, globals, functions, static_decls);
+        let out = generate_asc_module(&store, module, &AscOptions::default())
+            .expect("module should generate");
+        assert!(out.contains("export class mydsp {"));
+        assert!(out.contains("getNumInputs(): i32 { return 1; }"));
+        assert!(out.contains("getNumOutputs(): i32 { return 2; }"));
+        assert!(out.contains("compute(count: i32, inputs: Array<Array<f32>>, outputs: Array<Array<f32>>): void"));
+        assert!(out.contains("// Language: AssemblyScript"));
+    }
+
+    #[test]
+    fn emits_this_prefix_for_struct_access() {
+        let mut store = FirStore::new();
+        let mut b = FirBuilder::new(&mut store);
+        let val = b.float32(0.5);
+        let store_field = b.store_var("fHslider0", AccessType::Struct, val);
+        let body = b.block(&[store_field]);
+        let fun_ty = FirType::Fun {
+            args: vec![FirType::Ptr(Box::new(FirType::Obj)), FirType::Int32],
+            ret: Box::new(FirType::Void),
+        };
+        let args = vec![
+            NamedType { name: "dsp".to_owned(), typ: FirType::Ptr(Box::new(FirType::Obj)) },
+            NamedType { name: "sample_rate".to_owned(), typ: FirType::Int32 },
+        ];
+        let fun = b.declare_fun("instanceConstants", fun_ty, &args, Some(body), false);
+        let dsp_struct = b.block(&[]);
+        let globals = b.block(&[]);
+        let functions = b.block(&[fun]);
+        let static_decls = b.block(&[]);
+        let module = b.module(0, 1, "mydsp", dsp_struct, globals, functions, static_decls);
+        let out = generate_asc_module(&store, module, &AscOptions::default())
+            .expect("module should generate");
+        assert!(out.contains("this.fHslider0 = 0.5;"));
+        assert!(out.contains("instanceConstants(sample_rate: i32): void {"));
+    }
+}

--- a/crates/codegen/src/backends/asc/mod.rs
+++ b/crates/codegen/src/backends/asc/mod.rs
@@ -170,9 +170,6 @@ pub fn generate_asc_module(
     // are emitted as module-level `export function`s before the class.
     emit_toplevel_functions(store, &mut out, options, &class_name, module.globals)?;
 
-    // Compile-time constant tables become module-level `const`s.
-    emit_static_tables(store, &mut out, options, module.static_decls)?;
-
     let _ = writeln!(out, "export class {class_name} {{");
 
     // ---- fields: DSP struct state + globals (non-function) ----
@@ -183,29 +180,26 @@ pub fn generate_asc_module(
     }
     emit_section_fields(store, &mut out, options, &class_name, module.dsp_struct, 1)?;
     emit_section_fields(store, &mut out, options, &class_name, module.globals, 1)?;
+
+    // Compile-time constant tables become `static` class members so the
+    // qualified `ClassName.table` references resolve, mirroring the C++ asc
+    // backend's class-static table placement (which downstream tooling's
+    // static-field hoisting also expects).
+    emit_static_tables(store, &mut out, options, module.static_decls)?;
     let _ = writeln!(out);
 
-    // ---- DSP API methods ----
-    emit_dsp_contract_methods(
+    // ---- methods, in the C++ produceClass order ----
+    // Downstream tooling extracts method bodies by FIRST textual occurrence of
+    // `name(`, so every instance* DEFINITION must precede the synthesized
+    // instanceInit/init methods that CALL them (mirroring the C++ backend).
+    emit_methods_canonical_order(
+        store,
         &mut out,
-        module.num_inputs,
-        module.num_outputs,
+        options,
         &class_name,
-        &module.name,
+        &module,
         &declared_functions,
-        1,
-    );
-
-    // JSON snapshot for tooling (UI/param extraction), mirroring the C++ asc
-    // backend's getJSON().
-    if let Some(json) = options.json.as_deref() {
-        let _ = writeln!(out, "    getJSON(): string {{");
-        let _ = writeln!(out, "        return \"{}\";", escape_as_string(json));
-        let _ = writeln!(out, "    }}");
-    }
-
-    // ---- declared functions (compute, instance*, etc.) as class methods ----
-    emit_section_methods(store, &mut out, options, &class_name, module.functions, 1)?;
+    )?;
 
     let _ = writeln!(out, "}}");
     Ok(out)
@@ -255,57 +249,156 @@ fn emit_toplevel_functions(
     Ok(())
 }
 
-/// Emits the standard Faust DSP API surface in AssemblyScript form, synthesizing
-/// any methods the FIR module did not declare itself.
-fn emit_dsp_contract_methods(
+/// Emits every class method in the C++ `produceClass` order, pulling declared
+/// FIR functions when present and synthesizing the rest.
+///
+/// Order: info getters, getJSON, metadata/buildUserInterface, classInit,
+/// instanceResetUserInterface, instanceClear, instanceConstants, instanceInit,
+/// init, compute, then any remaining declared functions.
+fn emit_methods_canonical_order(
+    store: &FirStore,
     out: &mut String,
-    num_inputs: usize,
-    num_outputs: usize,
+    options: &AscOptions,
     class_name: &str,
-    module_name: &str,
+    module: &ModuleView,
     declared: &[String],
-    indent: usize,
-) {
-    let tab = "    ".repeat(indent);
+) -> Result<(), CodegenError> {
     let has = |n: &str| declared.iter().any(|d| d == n);
+    let mut emitted: Vec<&str> = Vec::new();
 
-    let _ = writeln!(out, "{tab}getNumInputs(): i32 {{ return {num_inputs}; }}");
-    let _ = writeln!(out, "{tab}getNumOutputs(): i32 {{ return {num_outputs}; }}");
-    let _ = writeln!(out, "{tab}getSampleRate(): i32 {{ return this.fSampleRate; }}");
-    let _ = writeln!(out, "{tab}static classInit(sample_rate: i32): void {{}}");
+    let _ = writeln!(out, "    getSampleRate(): i32 {{");
+    let _ = writeln!(out, "        return this.fSampleRate;");
+    let _ = writeln!(out, "    }}");
+    let _ = writeln!(out, "    getNumInputs(): i32 {{");
+    let _ = writeln!(out, "        return {};", module.num_inputs);
+    let _ = writeln!(out, "    }}");
+    let _ = writeln!(out, "    getNumOutputs(): i32 {{");
+    let _ = writeln!(out, "        return {};", module.num_outputs);
+    let _ = writeln!(out, "    }}");
 
-    if !has("instanceConstants") {
-        let _ = writeln!(out, "{tab}instanceConstants(sample_rate: i32): void {{");
-        let _ = writeln!(out, "{tab}    this.fSampleRate = sample_rate;");
-        let _ = writeln!(out, "{tab}}}");
+    // JSON snapshot for tooling (UI/param extraction), mirroring the C++ asc
+    // backend's getJSON().
+    if let Some(json) = options.json.as_deref() {
+        let _ = writeln!(out, "    getJSON(): string {{");
+        let _ = writeln!(out, "        return \"{}\";", escape_as_string(json));
+        let _ = writeln!(out, "    }}");
     }
-    if !has("instanceResetUserInterface") {
-        let _ = writeln!(out, "{tab}instanceResetUserInterface(): void {{}}");
+
+    for name in ["metadata", "buildUserInterface"] {
+        if has(name) {
+            emit_declared_method(store, out, options, class_name, module.functions, name)?;
+            emitted.push(name);
+        }
     }
-    if !has("instanceClear") {
-        let _ = writeln!(out, "{tab}instanceClear(): void {{}}");
+
+    let _ = writeln!(out, "    static classInit(sample_rate: i32): void {{");
+    let _ = writeln!(out, "    }}");
+
+    for name in [
+        "instanceResetUserInterface",
+        "instanceClear",
+        "instanceConstants",
+    ] {
+        if has(name) {
+            emit_declared_method(store, out, options, class_name, module.functions, name)?;
+            emitted.push(name);
+        } else if name == "instanceConstants" {
+            let _ = writeln!(out, "    instanceConstants(sample_rate: i32): void {{");
+            let _ = writeln!(out, "        this.fSampleRate = sample_rate;");
+            let _ = writeln!(out, "    }}");
+        } else {
+            let _ = writeln!(out, "    {name}(): void {{");
+            let _ = writeln!(out, "    }}");
+        }
     }
-    let _ = writeln!(out, "{tab}instanceInit(sample_rate: i32): void {{");
-    let _ = writeln!(out, "{tab}    this.instanceConstants(sample_rate);");
-    let _ = writeln!(out, "{tab}    this.instanceResetUserInterface();");
-    let _ = writeln!(out, "{tab}    this.instanceClear();");
-    let _ = writeln!(out, "{tab}}}");
-    let _ = writeln!(out, "{tab}init(sample_rate: i32): void {{");
-    let _ = writeln!(out, "{tab}    {class_name}.classInit(sample_rate);");
-    let _ = writeln!(out, "{tab}    this.instanceInit(sample_rate);");
-    let _ = writeln!(out, "{tab}}}");
-    if !has("metadata") {
-        let _ = writeln!(out, "{tab}// metadata: name {module_name}");
-    }
-    if !has("buildUserInterface") {
-        let _ = writeln!(out, "{tab}// ui openbox {module_name}");
-    }
-    if !has("compute") {
+
+    let _ = writeln!(out, "    instanceInit(sample_rate: i32): void {{");
+    let _ = writeln!(out, "        this.instanceConstants(sample_rate);");
+    let _ = writeln!(out, "        this.instanceResetUserInterface();");
+    let _ = writeln!(out, "        this.instanceClear();");
+    let _ = writeln!(out, "    }}");
+    let _ = writeln!(out, "    init(sample_rate: i32): void {{");
+    let _ = writeln!(out, "        {class_name}.classInit(sample_rate);");
+    let _ = writeln!(out, "        this.instanceInit(sample_rate);");
+    let _ = writeln!(out, "    }}");
+
+    if has("compute") {
+        emit_declared_method(store, out, options, class_name, module.functions, "compute")?;
+        emitted.push("compute");
+    } else {
         let _ = writeln!(
             out,
-            "{tab}compute(count: i32, inputs: Array<Array<{FAUST_FLOAT}>>, outputs: Array<Array<{FAUST_FLOAT}>>): void {{}}"
+            "    compute(count: i32, inputs: Array<Array<{FAUST_FLOAT}>>, outputs: Array<Array<{FAUST_FLOAT}>>): void {{"
         );
+        let _ = writeln!(out, "    }}");
     }
+
+    // Remaining declared functions in original order.
+    let FirMatch::Block(items) = match_fir(store, module.functions) else {
+        return Err(invalid_section("functions", module.functions, store));
+    };
+    for item in items {
+        if let FirMatch::DeclareFun {
+            name, typ, args, body, ..
+        } = match_fir(store, item)
+        {
+            if emitted.iter().any(|done| *done == name) {
+                continue;
+            }
+            emit_declare_fun(
+                store,
+                out,
+                options,
+                class_name,
+                DeclareFunView {
+                    name: &name,
+                    typ: &typ,
+                    named_args: &args,
+                    body,
+                },
+                1,
+                /* as_method = */ true,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// Emits one declared FIR function (by name) as a class method.
+fn emit_declared_method(
+    store: &FirStore,
+    out: &mut String,
+    options: &AscOptions,
+    class_name: &str,
+    functions: FirId,
+    method: &str,
+) -> Result<(), CodegenError> {
+    let FirMatch::Block(items) = match_fir(store, functions) else {
+        return Err(invalid_section("functions", functions, store));
+    };
+    for item in items {
+        if let FirMatch::DeclareFun {
+            name, typ, args, body, ..
+        } = match_fir(store, item)
+            && name == method
+        {
+            return emit_declare_fun(
+                store,
+                out,
+                options,
+                class_name,
+                DeclareFunView {
+                    name: &name,
+                    typ: &typ,
+                    named_args: &args,
+                    body,
+                },
+                1,
+                /* as_method = */ true,
+            );
+        }
+    }
+    Ok(())
 }
 
 /// Collects declared function names to decide which DSP API stubs to synthesize.
@@ -344,42 +437,6 @@ fn emit_section_fields(
             }
             // functions / struct-type decls are emitted elsewhere or ignored here
             _ => {}
-        }
-    }
-    Ok(())
-}
-
-/// Emits a module section as class methods (`DeclareFun` only).
-fn emit_section_methods(
-    store: &FirStore,
-    out: &mut String,
-    options: &AscOptions,
-    class_name: &str,
-    section_id: FirId,
-    indent: usize,
-) -> Result<(), CodegenError> {
-    let FirMatch::Block(items) = match_fir(store, section_id) else {
-        return Err(invalid_section("functions", section_id, store));
-    };
-    for item in items {
-        if let FirMatch::DeclareFun {
-            name, typ, args, body, ..
-        } = match_fir(store, item)
-        {
-            emit_declare_fun(
-                store,
-                out,
-                options,
-                class_name,
-                DeclareFunView {
-                    name: &name,
-                    typ: &typ,
-                    named_args: &args,
-                    body,
-                },
-                indent,
-                /* as_method = */ true,
-            )?;
         }
     }
     Ok(())
@@ -784,34 +841,34 @@ fn emit_member_decl(typ: &FirType, name: &str, options: &AscOptions) -> String {
 
 /// Maps a bare FIR math/function name to the AssemblyScript spelling.
 ///
-/// Mirrors the C++ asc backend's `gMathLibTable`: 32-bit (`*f`) intrinsics map to
-/// `Mathf.*`, double versions to `Math.*`, `abs`/`fabs` to `Math.abs`, and the
-/// min/max helpers to AssemblyScript's generic `min<T>`/`max<T>`.
+/// FAUST_FLOAT is f32 here (single precision), so unsuffixed float math names
+/// mean f32 — exactly how the C++ backend resolves them by real type. C++
+/// narrows doubles implicitly, AssemblyScript does not, so emitting the f64
+/// variants produces AS200 errors at every `f32` assignment (and would be
+/// numerically unfaithful to single-precision Faust anyway). The reference
+/// C++ asc backend output uses `Mathf.*` / `min<f32>` exclusively in single
+/// precision.
 fn map_fun_name(name: &str) -> String {
     match name {
-        "abs" | "fabs" => return "Math.abs".to_owned(),
-        "fabsf" => return "Mathf.abs".to_owned(),
+        "abs" | "fabs" | "fabsf" => return "Mathf.abs".to_owned(),
         "min_i" => return "min<i32>".to_owned(),
         "max_i" => return "max<i32>".to_owned(),
-        // single-precision min/max (Faust `*f` spelling) -> generic f32 helpers
-        "min_f" | "fminf" => return "min<f32>".to_owned(),
-        "max_f" | "fmaxf" => return "max<f32>".to_owned(),
-        // double-precision min/max -> generic f64 helpers
-        "min_" | "fmin" => return "min<f64>".to_owned(),
-        "max_" | "fmax" => return "max<f64>".to_owned(),
+        "min_f" | "fminf" | "min_" | "fmin" => return "min<f32>".to_owned(),
+        "max_f" | "fmaxf" | "max_" | "fmax" => return "max<f32>".to_owned(),
         // fmod has no Math helper; AssemblyScript uses the `%` operator instead,
-        // but as a call site we fall back to the f64/f32 remainder helpers.
+        // but as a call site we fall back to the remainder helper.
         "fmod" | "fmodf" => return "_fmod".to_owned(),
         _ => {}
     }
-    // float (32-bit) intrinsics -> Mathf.*, double -> Math.*
+    // Both the `*f`-suffixed and unsuffixed spellings resolve to the f32
+    // intrinsics (FAUST_FLOAT = f32).
     if let Some(stripped) = name.strip_suffix('f')
         && let Some(op) = FirMathOp::from_symbol(stripped)
     {
         return format!("Mathf.{}", op.symbol());
     }
     if let Some(op) = FirMathOp::from_symbol(name) {
-        return format!("Math.{}", op.symbol());
+        return format!("Mathf.{}", op.symbol());
     }
     name.to_owned()
 }
@@ -863,7 +920,7 @@ fn emit_type(typ: &FirType, options: &AscOptions) -> String {
     }
 }
 
-/// Emits `DeclareTable(Static)` nodes as module-level `const` StaticArrays.
+/// Emits `DeclareTable(Static)` nodes as `static` class-member StaticArrays.
 fn emit_static_tables(
     store: &FirStore,
     out: &mut String,
@@ -880,7 +937,7 @@ fn emit_static_tables(
             if values.is_empty() {
                 let _ = writeln!(
                     out,
-                    "const {name}: StaticArray<{ty}> = new StaticArray<{ty}>(0);"
+                    "    static {name}: StaticArray<{ty}> = new StaticArray<{ty}>(0);"
                 );
             } else {
                 let mut elems = Vec::with_capacity(values.len());
@@ -889,7 +946,7 @@ fn emit_static_tables(
                 }
                 let _ = writeln!(
                     out,
-                    "const {name}: StaticArray<{ty}> = StaticArray.fromArray<{ty}>([{}]);",
+                    "    static {name}: StaticArray<{ty}> = StaticArray.fromArray<{ty}>([{}]);",
                     elems.join(", ")
                 );
             }
@@ -1046,8 +1103,10 @@ mod tests {
         let out = generate_asc_module(&store, module, &AscOptions::default())
             .expect("module should generate");
         assert!(out.contains("export class mydsp {"));
-        assert!(out.contains("getNumInputs(): i32 { return 1; }"));
-        assert!(out.contains("getNumOutputs(): i32 { return 2; }"));
+        assert!(out.contains("getNumInputs(): i32 {"));
+        assert!(out.contains("        return 1;"));
+        assert!(out.contains("getNumOutputs(): i32 {"));
+        assert!(out.contains("        return 2;"));
         assert!(out.contains("compute(count: i32, inputs: Array<Array<f32>>, outputs: Array<Array<f32>>): void"));
         assert!(out.contains("// Language: AssemblyScript"));
     }

--- a/crates/codegen/src/backends/mod.rs
+++ b/crates/codegen/src/backends/mod.rs
@@ -22,6 +22,7 @@
 
 pub(crate) mod faust_api;
 
+pub mod asc;
 pub mod c;
 pub mod cmajor;
 pub mod codebox;

--- a/crates/compiler/src/cli/args.rs
+++ b/crates/compiler/src/cli/args.rs
@@ -17,6 +17,7 @@ pub enum CliLang {
     C,
     #[value(alias = "cxx", alias = "c++")]
     Cpp,
+    Asc,
     Fir,
     #[value(alias = "interp-fbc")]
     Interp,
@@ -107,10 +108,10 @@ pub struct CliArgs {
     /// Emit strict C++-style JSON description.
     #[arg(long = "json", action = ArgAction::SetTrue)]
     pub dump_json: bool,
-    /// Select backend language (Faust-style): `-lang c`, `-lang cpp`, `-lang cranelift`, `-lang fir`, `-lang interp`, `-lang julia`, `-lang wasm`, or `-lang wast`.
+    /// Select backend language (Faust-style): `-lang asc`, `-lang c`, `-lang cpp`, `-lang cranelift`, `-lang fir`, `-lang interp`, `-lang julia`, `-lang wasm`, or `-lang wast`.
     ///
     /// This option is equivalent to `--dump-c` / `--dump-cpp` / `--dump-fir`
-    /// / `--dump-interp` / `--dump-cranelift` / `-lang julia` / `-lang wasm` / `-lang wast`.
+    /// / `--dump-interp` / `--dump-cranelift` / `-lang asc` / `-lang julia` / `-lang wasm` / `-lang wast`.
     #[arg(long = "lang", value_enum, allow_hyphen_values = true)]
     pub lang: Option<CliLang>,
     /// Print version information and exit.

--- a/crates/compiler/src/cli/runner.rs
+++ b/crates/compiler/src/cli/runner.rs
@@ -22,6 +22,7 @@ use codegen::backends::interp::{
     FbcCppOptions, InterpOptions, generate_cpp_from_fbc, generate_interp_module, read_fbc,
     write_fbc,
 };
+use codegen::backends::asc::{AscOptions, generate_asc_module};
 use codegen::backends::julia::{JuliaOptions, JuliaRealType, generate_julia_module};
 use codegen::backends::wasm::{WasmOptions, generate_wasm_module};
 use codegen::fixtures::backend_test_fixtures;
@@ -41,7 +42,7 @@ use super::timer::CompilationTimer;
 pub fn print_global_usage_and_exit() -> ! {
     eprintln!("Usage:");
     eprintln!(
-        "  cargo run -p compiler -- -lang c|cpp|fir|julia|wast <input.dsp> [-o <file>] [-I <dir> ...] [--class-name <name>] [--super-class-name <name>] [--signal-fir-lane fast] [--error-format human|json] [--error-verbosity standard|debug]"
+        "  cargo run -p compiler -- -lang asc|c|cpp|fir|julia|wast <input.dsp> [-o <file>] [-I <dir> ...] [--class-name <name>] [--super-class-name <name>] [--signal-fir-lane fast] [--error-format human|json] [--error-verbosity standard|debug]"
     );
     eprintln!("                           [--no-fir-verify] [--fir-verify-strict]");
     eprintln!("  cargo run -p compiler -- --golden <input.dsp>");
@@ -181,6 +182,7 @@ pub fn cli_lang_name(lang: CliLang) -> &'static str {
         CliLang::Fir => "fir",
         CliLang::Interp => "interp",
         CliLang::Cranelift => "cranelift",
+        CliLang::Asc => "asc",
         CliLang::Julia => "julia",
         CliLang::Wasm => "wasm",
         CliLang::Wast => "wast",
@@ -644,7 +646,12 @@ pub fn run_main() {
         || matches!(
             cli.lang,
             Some(
-                CliLang::Fir | CliLang::Interp | CliLang::Cranelift | CliLang::Wasm | CliLang::Wast
+                CliLang::Fir
+                    | CliLang::Interp
+                    | CliLang::Cranelift
+                    | CliLang::Wasm
+                    | CliLang::Wast
+                    | CliLang::Asc
             )
         ))
         && cli.architecture.is_some()
@@ -840,6 +847,39 @@ pub fn run_main() {
                 }
                 Err(err) => {
                     eprintln!("WAST fixture codegen failed: {err}");
+                    std::process::exit(1);
+                }
+            }
+            return;
+        }
+
+        if matches!(cli.lang, Some(CliLang::Asc)) {
+            let options = AscOptions {
+                class_name: selected_class_name(&cli),
+                ..AscOptions::default()
+            };
+            match generate_asc_module(&store, module, &options) {
+                Ok(asc) => {
+                    emit_output(&asc, cli.output.as_ref());
+                    if cli.dump_json {
+                        let output = require_companion_output_path(&cli);
+                        let compile_options = compile_options_json_string(Some("asc"), cli.double);
+                        match compile_fixture_to_json_text(
+                            &store,
+                            module,
+                            compile_options,
+                            cli.double,
+                        ) {
+                            Ok(json) => emit_json_companion_output(&json, output),
+                            Err(err) => {
+                                eprintln!("JSON fixture generation failed: {err}");
+                                std::process::exit(1);
+                            }
+                        }
+                    }
+                }
+                Err(err) => {
+                    eprintln!("AssemblyScript fixture codegen failed: {err}");
                     std::process::exit(1);
                 }
             }
@@ -1427,6 +1467,57 @@ pub fn run_main() {
             }
             Err(err) => {
                 eprintln!("Cranelift FIR pipeline failed: {err}");
+                print_structured_diagnostics(&err, cli.error_format, cli.error_verbosity);
+                std::process::exit(1);
+            }
+        }
+        timer.total();
+        return;
+    }
+
+    if matches!(cli.lang, Some(CliLang::Asc)) {
+        let mut timer = CompilationTimer::new(cli.timeout, cli.compilation_time);
+        let compiler = compiler_from_cli(&cli, Some(std::sync::Arc::clone(&cancel)));
+        let result = if cli.import_dir.is_empty() {
+            compiler.compile_file_default_to_fir_with_lane(
+                input_path,
+                selected_codegen_lane(&cli).into_compiler_lane(),
+            )
+        } else {
+            compiler.compile_file_to_fir_with_lane(
+                input_path,
+                &cli.import_dir,
+                selected_codegen_lane(&cli).into_compiler_lane(),
+            )
+        };
+        timer.phase("asc-codegen");
+
+        match result {
+            Ok(out) => {
+                let options = AscOptions {
+                    class_name: selected_class_name(&cli),
+                    ..AscOptions::default()
+                };
+                match generate_asc_module(&out.store, out.module, &options) {
+                    Ok(asc) => {
+                        emit_output(&asc, cli.output.as_ref());
+                        if cli.dump_json {
+                            emit_cli_json_companion_for_backend(
+                                &compiler,
+                                &cli,
+                                input_path,
+                                CliLang::Asc,
+                            );
+                        }
+                    }
+                    Err(err) => {
+                        eprintln!("AssemblyScript codegen failed: {err}");
+                        std::process::exit(1);
+                    }
+                }
+            }
+            Err(err) => {
+                eprintln!("AssemblyScript pipeline failed: {err}");
                 print_structured_diagnostics(&err, cli.error_format, cli.error_verbosity);
                 std::process::exit(1);
             }

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -53,6 +53,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use boxes::{BoxId, BoxMatch, dump_box, match_box};
+use codegen::backends::asc::{AscOptions, generate_asc_module};
 use codegen::backends::c::{COptions, CodegenError as CCodegenError, generate_c_module};
 use codegen::backends::cpp::{CodegenError, CppOptions, generate_cpp_module};
 use codegen::backends::interp::{
@@ -1487,6 +1488,9 @@ impl Compiler {
     ///
     /// Mirrors: `generateAuxFilesFromString` / `generateAuxFilesFromFile`
     /// (C++ Faust API).
+    ///
+    /// Additionally, faustwasm-style transpile requests using `-lang asc`
+    /// produce one AssemblyScript source artifact (honoring `-cn` and `-o`).
     pub fn generate_aux_files(
         &self,
         request: &GenerateAuxFilesRequest,
@@ -1494,6 +1498,14 @@ impl Compiler {
         let argv: Vec<String> = request.args.split_whitespace().map(str::to_owned).collect();
         let search_paths = parse_search_paths_from_argv(&argv);
         let double = argv.iter().any(|a| a == "-double");
+
+        // faustwasm-style transpile request: `-lang asc` produces one
+        // AssemblyScript source artifact instead of the flag-driven outputs.
+        if let Some(position) = argv.iter().position(|arg| arg == "-lang")
+            && argv.get(position + 1).map(String::as_str) == Some("asc")
+        {
+            return self.generate_asc_aux_file(request, &argv, &search_paths);
+        }
 
         let wants_cpp = argv.iter().any(|a| a == "-cpp");
         let wants_c = argv.iter().any(|a| a == "-c");
@@ -1597,6 +1609,62 @@ impl Compiler {
         }
 
         Ok(artifacts)
+    }
+
+    /// Generates the AssemblyScript source artifact for a `-lang asc`
+    /// `generateAuxFiles` request (`-cn` selects the class name, `-o` the
+    /// artifact path; `request.virtual_sources` supplies in-memory libraries).
+    fn generate_asc_aux_file(
+        &self,
+        request: &GenerateAuxFilesRequest,
+        argv: &[String],
+        search_paths: &[PathBuf],
+    ) -> Result<Vec<AuxFileArtifact>, FaustwasmServiceError> {
+        let arg_value = |flag: &str| {
+            argv.iter()
+                .position(|arg| arg == flag)
+                .and_then(|position| argv.get(position + 1))
+                .cloned()
+        };
+        let signals = self
+            .compile_source_to_signals_with_import_context(
+                &request.source_name,
+                &request.source,
+                search_paths,
+                &request.virtual_sources,
+            )
+            .map_err(|error| FaustwasmServiceError::invalid_argument(error.to_string()))?;
+        let lowered = lower_signals_to_fir(
+            &request.source_name,
+            &signals,
+            SignalFirLane::TransformFastLane,
+            self.fir_verify,
+            self.real_type,
+            self.max_copy_delay,
+            self.delay_line_threshold,
+        )
+        .map_err(|error| {
+            FaustwasmServiceError::invalid_argument(
+                lower_fir_error_to_compiler(&request.source_name, error).to_string(),
+            )
+        })?;
+
+        let class_name = arg_value("-cn").unwrap_or_else(|| {
+            sanitize_cpp_ident(source_name_to_class(&request.source_name).as_str())
+        });
+        let options = AscOptions {
+            class_name: Some(class_name.clone()),
+            ..AscOptions::default()
+        };
+        let asc = generate_asc_module(&lowered.store, lowered.module, &options)
+            .map_err(|error| FaustwasmServiceError::invalid_argument(error.to_string()))?;
+
+        let path = arg_value("-o").unwrap_or_else(|| format!("{class_name}.ts"));
+        Ok(vec![AuxFileArtifact {
+            path,
+            content: asc.into_bytes(),
+            binary: false,
+        }])
     }
 
     /// Parses + evaluates + propagates one file with default import search path,

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -1652,8 +1652,31 @@ impl Compiler {
         let class_name = arg_value("-cn").unwrap_or_else(|| {
             sanitize_cpp_ident(source_name_to_class(&request.source_name).as_str())
         });
+
+        // Strict C++-style JSON snapshot, embedded as getJSON() in the output —
+        // downstream tooling parses it for inputs/outputs and the UI tree
+        // (mirrors the C++ asc backend's getJSON()).
+        let json = build_strict_json_description(
+            &lowered.store,
+            lowered.module,
+            StrictJsonContext {
+                filename: source_name_to_filename(&request.source_name),
+                include_pathnames: Vec::new(),
+                library_list: Vec::new(),
+                top_level_meta: json_meta_entries_from_snapshot(&signals.compilation_metadata),
+                compile_options: compile_options_json_string(
+                    Some("asc"),
+                    self.real_type == RealType::Float64,
+                ),
+                double_precision: self.real_type == RealType::Float64,
+            },
+        )
+        .ok()
+        .map(|json| json.render());
+
         let options = AscOptions {
             class_name: Some(class_name.clone()),
+            json,
             ..AscOptions::default()
         };
         let asc = generate_asc_module(&lowered.store, lowered.module, &options)

--- a/crates/compiler/src/tests.rs
+++ b/crates/compiler/src/tests.rs
@@ -658,3 +658,25 @@ fn compiler_generate_aux_files_emits_assemblyscript_for_lang_asc() {
     assert!(text.contains("export class Probe"));
     assert!(text.contains("compute(count: i32"));
 }
+
+#[test]
+fn identical_widgets_under_distinct_groups_stay_distinct() {
+    // Regression: the same widget box reached under DIFFERENT interpolated
+    // group labels must produce distinct controls (C++ threads the group
+    // path into widget signals). A box-id-only UI dedupe collapses all three
+    // sliders into one (observed as DX7 operators losing their parameter
+    // groups).
+    let compiler = Compiler::new();
+    let json = compiler
+        .compile_source_to_json(
+            "lbl.dsp",
+            "process = par(i, 3, vgroup(\"Op %i\", hslider(\"g\", 0, 0, 1, 0.1))) :> _;",
+        )
+        .expect("compiles");
+    for address in ["/lbl/Op 0/g", "/lbl/Op 1/g", "/lbl/Op 2/g"] {
+        assert!(
+            json.contains(&format!("\"address\": \"{address}\"")),
+            "missing widget address {address} in JSON:\n{json}"
+        );
+    }
+}

--- a/crates/compiler/src/tests.rs
+++ b/crates/compiler/src/tests.rs
@@ -680,3 +680,31 @@ fn identical_widgets_under_distinct_groups_stay_distinct() {
         );
     }
 }
+
+#[test]
+fn ui_children_sort_lexicographically_by_raw_label() {
+    // C++ parity: group children are ordered by the RAW label including the
+    // "[n] " ordering prefix, using plain byte-wise comparison ("[10]" sorts
+    // before "[2]"; unnumbered labels interleave by their own spelling).
+    // Reference: C++ faust JSON for this exact source.
+    let compiler = Compiler::new();
+    let json = compiler
+        .compile_source_to_json(
+            "ord.dsp",
+            "process = hgroup(\"top\", hslider(\"[10] b\",0,0,1,0.1) + hslider(\"[2] a\",0,0,1,0.1) + hslider(\"zz\",0,0,1,0.1) + hslider(\"Aa\",0,0,1,0.1));",
+        )
+        .expect("compiles");
+    let order: Vec<usize> = [
+        "\"label\": \"Aa\"",
+        "\"label\": \"b\"",
+        "\"label\": \"a\"",
+        "\"label\": \"zz\"",
+    ]
+    .iter()
+    .map(|needle| json.find(needle).expect("label present"))
+    .collect();
+    assert!(
+        order.windows(2).all(|pair| pair[0] < pair[1]),
+        "expected Aa, b, a, zz order in JSON:\n{json}"
+    );
+}

--- a/crates/compiler/src/tests.rs
+++ b/crates/compiler/src/tests.rs
@@ -639,3 +639,22 @@ fn compiler_generate_aux_files_cpp_flag_produces_cpp_artifact() {
     assert_eq!(artifacts[0].path, "zero.cpp");
     assert!(!artifacts[0].binary);
 }
+
+#[test]
+fn compiler_generate_aux_files_emits_assemblyscript_for_lang_asc() {
+    let compiler = Compiler::new();
+    let files = compiler
+        .generate_aux_files(&GenerateAuxFilesRequest {
+            source_name: "gain.dsp".to_owned(),
+            source: "process = _ * 0.5;".to_owned(),
+            args: "-lang asc -cn Probe -o /Probe.ts".to_owned(),
+            virtual_sources: VirtualSourceMap::default(),
+        })
+        .expect("asc aux-file generation should succeed");
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].path, "/Probe.ts");
+    assert!(!files[0].binary);
+    let text = String::from_utf8(files[0].content.clone()).expect("utf-8 asc source");
+    assert!(text.contains("export class Probe"));
+    assert!(text.contains("compute(count: i32"));
+}

--- a/crates/compiler/src/tests.rs
+++ b/crates/compiler/src/tests.rs
@@ -708,3 +708,49 @@ fn ui_children_sort_lexicographically_by_raw_label() {
         "expected Aa, b, a, zz order in JSON:\n{json}"
     );
 }
+
+#[test]
+fn replicated_widgets_wire_distinct_dsp_fields() {
+    // Regression for the widget-identity collapse: UI extraction listed every
+    // replicated control, but the SIGNAL path aliased same-box widgets across
+    // group contexts to one control — a DX7 voice wired only 34 of 147
+    // parameters (envelopes stuck at init values; a piano patch degenerated
+    // into a percussive thump). UI-level assertions cannot catch this, so
+    // check the generated code: three group instances must produce three
+    // DSP fields, like the C++ compiler.
+    let compiler = Compiler::new();
+    let cpp = compiler
+        .compile_source_to_cpp(
+            "rep.dsp",
+            "process = par(i, 3, vgroup(\"Op %i\", hslider(\"g\", 0, 0, 1, 0.1))) :> _;",
+            &codegen::backends::cpp::CppOptions::default(),
+        )
+        .expect("compiles");
+    for field in ["fHslider0", "fHslider1", "fHslider2"] {
+        assert!(
+            cpp.contains(&format!("FAUSTFLOAT {field};")),
+            "missing DSP field {field} — replicated widgets collapsed:\n{cpp}"
+        );
+    }
+}
+
+#[test]
+fn ad_seed_references_unify_to_one_control() {
+    // Counterpart guard: a widget referenced from a `fad(...)` SEED is a
+    // differentiation parameter — every reference (body and seed, in any
+    // group context) must resolve to the SAME control, even though the body
+    // reference sits inside a group and the seed is walked context-free.
+    let compiler = Compiler::new();
+    let cpp = compiler
+        .compile_source_to_cpp(
+            "seed.dsp",
+            "g = hslider(\"g\", 0.5, 0, 1, 0.01);\nprocess = +~vgroup(\"fb\", fad(*(g), g));",
+            &codegen::backends::cpp::CppOptions::default(),
+        )
+        .expect("compiles");
+    assert!(cpp.contains("FAUSTFLOAT fHslider0;"));
+    assert!(
+        !cpp.contains("FAUSTFLOAT fHslider1;"),
+        "fad seed reference forked into a second control:\n{cpp}"
+    );
+}

--- a/crates/compiler/tests/signal_pipeline.rs
+++ b/crates/compiler/tests/signal_pipeline.rs
@@ -1468,6 +1468,9 @@ fn corpus_relative_group_label_rebases_explicit_group_to_parent() {
         "rep_63_ui_relative_group_rebase",
     );
     assert_eq!(root_children.len(), 2);
+    // Root-forest order keeps insertion order (the `../` rebase is a Rust-side
+    // extension with no C++ reference; lexicographic ordering applies only to
+    // children within a group).
     assert!(expect_ui_group(&out, root_children[0], UiGroupKind::Horizontal, "Foo").is_empty());
     let bar_children = expect_ui_group(&out, root_children[1], UiGroupKind::Vertical, "Bar");
     assert_eq!(bar_children.len(), 1);
@@ -1489,6 +1492,9 @@ fn corpus_relative_group_label_clamps_navigation_at_root() {
         "rep_64_ui_relative_group_root_clamp",
     );
     assert_eq!(root_children.len(), 2);
+    // Root-forest order keeps insertion order (the `../` rebase is a Rust-side
+    // extension with no C++ reference; lexicographic ordering applies only to
+    // children within a group).
     assert!(expect_ui_group(&out, root_children[0], UiGroupKind::Horizontal, "Foo").is_empty());
     let bar_children = expect_ui_group(&out, root_children[1], UiGroupKind::Vertical, "Bar");
     assert_eq!(bar_children.len(), 1);

--- a/crates/propagate/src/ui_build.rs
+++ b/crates/propagate/src/ui_build.rs
@@ -122,7 +122,7 @@ impl UiCollector {
         metadata: UiMetadata,
         range: Option<ControlRange>,
     ) {
-        let order_key = ui::ordering_key_from_metadata(&metadata);
+        let order_key = ui::ordering_key_from_label(&label, &metadata);
         let id = self.register_control(source_node, context_hash, kind, label, metadata, range);
         self.builder.insert_input_control(path, id, order_key);
     }
@@ -138,7 +138,7 @@ impl UiCollector {
         metadata: UiMetadata,
         range: Option<ControlRange>,
     ) {
-        let order_key = ui::ordering_key_from_metadata(&metadata);
+        let order_key = ui::ordering_key_from_label(&label, &metadata);
         let id = self.register_control(source_node, context_hash, kind, label, metadata, range);
         self.builder.insert_output_control(path, id, order_key);
     }
@@ -151,7 +151,7 @@ impl UiCollector {
         label: String,
         metadata: UiMetadata,
     ) {
-        let order_key = ui::ordering_key_from_metadata(&metadata);
+        let order_key = ui::ordering_key_from_label(&label, &metadata);
         let id = self.register_control(
             source_node,
             context_hash,

--- a/crates/propagate/src/ui_build.rs
+++ b/crates/propagate/src/ui_build.rs
@@ -30,10 +30,16 @@ struct UiCollector {
     /// different group-path context (e.g. a slider that appears in both the body and the
     /// seed of a `fad(…)` call) and to create a cross-context alias rather than a second
     /// `ControlSpec` entry.
-    node_primary_id: AHashMap<BoxId, ControlId>,
     /// Memoisation table for the DAG walk — keyed by `(FlatBoxId, group_path_hash)` to allow
     /// the same structural widget to be registered once per distinct group context.
     visited: AHashMap<(FlatBoxId, u64), UiCollectSummary>,
+    /// First ControlId registered for each widget box, used to alias
+    /// AD-seed re-references (see `register_control`).
+    node_primary_id: AHashMap<BoxId, ControlId>,
+    /// Widget boxes referenced from an AD seed: differentiation parameters.
+    /// Every reference to such a box denotes the same control regardless of
+    /// group context.
+    ad_seed_parameters: AHashSet<BoxId>,
 }
 
 impl UiCollector {
@@ -42,8 +48,9 @@ impl UiCollector {
             builder: UiProgramBuilder::new(),
             controls: Vec::new(),
             control_ids: ControlIds::new(),
-            node_primary_id: AHashMap::new(),
             visited: AHashMap::new(),
+            node_primary_id: AHashMap::new(),
+            ad_seed_parameters: AHashSet::new(),
         }
     }
 
@@ -73,10 +80,12 @@ impl UiCollector {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn register_control(
         &mut self,
         source_node: BoxId,
         context_hash: u64,
+        in_ad_seed: bool,
         kind: ControlKind,
         label: String,
         metadata: UiMetadata,
@@ -88,12 +97,23 @@ impl UiCollector {
         if let Some(&existing_id) = self.control_ids.get(&key) {
             return existing_id;
         }
-        // Cross-context deduplication: if the same source node was already registered under
-        // a different group-path context (e.g. a slider that appears in both the body and
-        // the seed of a `fad(…)` call), reuse its existing ControlId and only add an alias
-        // for the new context key. This prevents duplicate ControlSpec entries for what is
-        // semantically one widget referenced from multiple positions in the box DAG.
-        if let Some(&primary_id) = self.node_primary_id.get(&source_node) {
+        // Cross-context aliasing applies ONLY inside AD seed subtrees: there
+        // the seed re-references a widget the compiler repositioned outside
+        // its original group wrapper (e.g. `fad(*(g), g)` differentiates with
+        // respect to the SAME `g` the body reads), so it must resolve to the
+        // already-registered control.
+        //
+        // Everywhere else the same widget box reached under DIFFERENT explicit
+        // group paths denotes DISTINCT controls — C++ propagation threads the
+        // group path into widget signals, so `par(i, N, vgroup("Op %i",
+        // hslider("g", ...)))` yields N separate controls (each with its own
+        // DSP field), not N aliases of one.
+        if in_ad_seed {
+            self.ad_seed_parameters.insert(source_node);
+        }
+        if (in_ad_seed || self.ad_seed_parameters.contains(&source_node))
+            && let Some(&primary_id) = self.node_primary_id.get(&source_node)
+        {
             self.control_ids.insert(key, primary_id);
             return primary_id;
         }
@@ -107,7 +127,7 @@ impl UiCollector {
             range,
         });
         self.control_ids.insert(key, id);
-        self.node_primary_id.insert(source_node, id);
+        self.node_primary_id.entry(source_node).or_insert(id);
         id
     }
 
@@ -117,13 +137,14 @@ impl UiCollector {
         source_node: BoxId,
         path: &[UiGroupSpec],
         context_hash: u64,
+        in_ad_seed: bool,
         kind: ControlKind,
         label: String,
         metadata: UiMetadata,
         range: Option<ControlRange>,
     ) {
         let order_key = ui::ordering_key_from_label(&label, &metadata);
-        let id = self.register_control(source_node, context_hash, kind, label, metadata, range);
+        let id = self.register_control(source_node, context_hash, in_ad_seed, kind, label, metadata, range);
         self.builder.insert_input_control(path, id, order_key);
     }
 
@@ -133,13 +154,14 @@ impl UiCollector {
         source_node: BoxId,
         path: &[UiGroupSpec],
         context_hash: u64,
+        in_ad_seed: bool,
         kind: ControlKind,
         label: String,
         metadata: UiMetadata,
         range: Option<ControlRange>,
     ) {
         let order_key = ui::ordering_key_from_label(&label, &metadata);
-        let id = self.register_control(source_node, context_hash, kind, label, metadata, range);
+        let id = self.register_control(source_node, context_hash, in_ad_seed, kind, label, metadata, range);
         self.builder.insert_output_control(path, id, order_key);
     }
 
@@ -148,6 +170,7 @@ impl UiCollector {
         source_node: BoxId,
         path: &[UiGroupSpec],
         context_hash: u64,
+        in_ad_seed: bool,
         label: String,
         metadata: UiMetadata,
     ) {
@@ -155,6 +178,7 @@ impl UiCollector {
         let id = self.register_control(
             source_node,
             context_hash,
+            in_ad_seed,
             ControlKind::Soundfile,
             label,
             metadata,
@@ -217,7 +241,7 @@ pub(crate) fn build_ui_program(
     options: &PropagateUiOptions,
 ) -> UiBuildOutput {
     let mut collector = UiCollector::new();
-    let _ = collect_ui_nodes(source_arena, box_tree, &[], &mut collector);
+    let _ = collect_ui_nodes(source_arena, box_tree, &[], false, &mut collector);
     collector.finish(options)
 }
 
@@ -238,6 +262,7 @@ fn collect_ui_nodes(
     source_arena: &TreeArena,
     box_tree: FlatBoxId,
     current_groups: &[UiGroupPathSegment],
+    in_ad_seed: bool,
     collector: &mut UiCollector,
 ) -> UiCollectSummary {
     // DAG deduplication: the flat box tree after `eval` is a structural DAG —
@@ -264,6 +289,7 @@ fn collect_ui_nodes(
                 box_tree.as_tree_id(),
                 &path,
                 context_hash,
+                in_ad_seed,
                 ControlKind::Button,
                 label,
                 metadata,
@@ -286,6 +312,7 @@ fn collect_ui_nodes(
                 box_tree.as_tree_id(),
                 &path,
                 context_hash,
+                in_ad_seed,
                 ControlKind::Checkbox,
                 label,
                 metadata,
@@ -310,6 +337,7 @@ fn collect_ui_nodes(
                 box_tree.as_tree_id(),
                 &path,
                 context_hash,
+                in_ad_seed,
                 ControlKind::VSlider,
                 label,
                 metadata,
@@ -339,6 +367,7 @@ fn collect_ui_nodes(
                 box_tree.as_tree_id(),
                 &path,
                 context_hash,
+                in_ad_seed,
                 ControlKind::HSlider,
                 label,
                 metadata,
@@ -368,6 +397,7 @@ fn collect_ui_nodes(
                 box_tree.as_tree_id(),
                 &path,
                 context_hash,
+                in_ad_seed,
                 ControlKind::NumEntry,
                 label,
                 metadata,
@@ -397,6 +427,7 @@ fn collect_ui_nodes(
                 box_tree.as_tree_id(),
                 &path,
                 context_hash,
+                in_ad_seed,
                 ControlKind::VBargraph,
                 label,
                 metadata,
@@ -426,6 +457,7 @@ fn collect_ui_nodes(
                 box_tree.as_tree_id(),
                 &path,
                 context_hash,
+                in_ad_seed,
                 ControlKind::HBargraph,
                 label,
                 metadata,
@@ -450,7 +482,8 @@ fn collect_ui_nodes(
                 normalize_widget_label_path(&decode_box_label(source_arena, label), current_groups);
             let path = canonical_group_path(&normalized.groups);
             let (label, metadata) = split_label_metadata(&normalized.raw_label);
-            collector.soundfile(box_tree.as_tree_id(), &path, context_hash, label, metadata);
+            collector.soundfile(box_tree.as_tree_id(), &path, context_hash,
+                in_ad_seed, label, metadata);
             UiCollectSummary {
                 has_ui: true,
                 preserve_ancestor_chain: false,
@@ -460,6 +493,7 @@ fn collect_ui_nodes(
             source_arena,
             body,
             current_groups,
+            in_ad_seed,
             collector,
             UiGroupKind::Vertical,
             box_tree.as_tree_id(),
@@ -468,6 +502,7 @@ fn collect_ui_nodes(
             source_arena,
             body,
             current_groups,
+            in_ad_seed,
             collector,
             UiGroupKind::Horizontal,
             box_tree.as_tree_id(),
@@ -476,18 +511,20 @@ fn collect_ui_nodes(
             source_arena,
             body,
             current_groups,
+            in_ad_seed,
             collector,
             UiGroupKind::Tab,
             box_tree.as_tree_id(),
         ),
         FlatNodeKind::ForwardAD { body, seed } => {
-            let body_s = collect_ui_nodes(source_arena, body, current_groups, collector);
+            let body_s = collect_ui_nodes(source_arena, body, current_groups, in_ad_seed, collector);
             // Differentiation seeds are global parameters whose UI position is
             // independent of any group that wraps the surrounding `fad(…)` call.
             // Visiting with an empty context ensures that subsequent references to
             // the same seed node (e.g. in the Rec feedback branch) hit the cache
-            // rather than being registered as duplicate controls.
-            let seed_s = collect_ui_nodes(source_arena, seed, &[], collector);
+            // rather than being registered as duplicate controls. The seed flag
+            // lets re-references of body widgets alias to their primary control.
+            let seed_s = collect_ui_nodes(source_arena, seed, &[], true, collector);
             UiCollectSummary {
                 has_ui: body_s.has_ui || seed_s.has_ui,
                 preserve_ancestor_chain: body_s.preserve_ancestor_chain
@@ -495,10 +532,10 @@ fn collect_ui_nodes(
             }
         }
         FlatNodeKind::ReverseAD { body, seeds } => {
-            let body_s = collect_ui_nodes(source_arena, body, current_groups, collector);
+            let body_s = collect_ui_nodes(source_arena, body, current_groups, in_ad_seed, collector);
             // Same rationale as ForwardAD: seed parameters are registered without
             // the surrounding group context so later references can find them.
-            let seeds_s = collect_ui_nodes(source_arena, seeds, &[], collector);
+            let seeds_s = collect_ui_nodes(source_arena, seeds, &[], true, collector);
             UiCollectSummary {
                 has_ui: body_s.has_ui || seeds_s.has_ui,
                 preserve_ancestor_chain: body_s.preserve_ancestor_chain
@@ -510,15 +547,17 @@ fn collect_ui_nodes(
         | FlatNodeKind::Ondemand(body)
         | FlatNodeKind::Upsampling(body)
         | FlatNodeKind::Downsampling(body) => {
-            collect_ui_nodes(source_arena, body, current_groups, collector)
+            collect_ui_nodes(source_arena, body, current_groups, in_ad_seed, collector)
         }
         FlatNodeKind::Seq(left, right)
         | FlatNodeKind::Par(left, right)
         | FlatNodeKind::Split(left, right)
         | FlatNodeKind::Merge(left, right)
         | FlatNodeKind::Rec(left, right) => {
-            let left_summary = collect_ui_nodes(source_arena, left, current_groups, collector);
-            let right_summary = collect_ui_nodes(source_arena, right, current_groups, collector);
+            let left_summary =
+                collect_ui_nodes(source_arena, left, current_groups, in_ad_seed, collector);
+            let right_summary =
+                collect_ui_nodes(source_arena, right, current_groups, in_ad_seed, collector);
             UiCollectSummary {
                 has_ui: left_summary.has_ui || right_summary.has_ui,
                 preserve_ancestor_chain: left_summary.preserve_ancestor_chain
@@ -552,6 +591,7 @@ fn collect_group_ui(
     source_arena: &TreeArena,
     body: FlatBoxId,
     current_groups: &[UiGroupPathSegment],
+    in_ad_seed: bool,
     collector: &mut UiCollector,
     kind: UiGroupKind,
     group_node: BoxId,
@@ -573,7 +613,7 @@ fn collect_group_ui(
         .ensure_group_path(&path)
         .expect("explicit group path must yield a terminal group");
 
-    let summary = collect_ui_nodes(source_arena, body, &nested_groups, collector);
+    let summary = collect_ui_nodes(source_arena, body, &nested_groups, in_ad_seed, collector);
     let keep_group =
         collector.builder.group_has_children(terminal) || summary.preserve_ancestor_chain;
     if !keep_group && terminal_preexisting.is_none() {

--- a/crates/propagate/tests/core_api.rs
+++ b/crates/propagate/tests/core_api.rs
@@ -664,6 +664,9 @@ fn propagate_with_ui_rebases_explicit_group_label_to_parent() {
     assert_eq!(out.ui.root_origin, UiRootOrigin::Synthesized);
     let root_children = expect_ui_group(&out.ui, out.ui.root, UiGroupKind::Vertical, "");
     assert_eq!(root_children.len(), 2);
+    // Root-forest order keeps insertion order (the `../` rebase is a Rust-side
+    // extension with no C++ reference; lexicographic ordering applies only to
+    // children within a group).
     assert!(expect_ui_group(&out.ui, root_children[0], UiGroupKind::Horizontal, "Foo").is_empty());
     let bar_children = expect_ui_group(&out.ui, root_children[1], UiGroupKind::Vertical, "Bar");
     assert_eq!(bar_children.len(), 1);
@@ -698,6 +701,9 @@ fn propagate_with_ui_clamps_relative_group_label_navigation_at_root() {
     assert_eq!(out.ui.root_origin, UiRootOrigin::Synthesized);
     let root_children = expect_ui_group(&out.ui, out.ui.root, UiGroupKind::Vertical, "");
     assert_eq!(root_children.len(), 2);
+    // Root-forest order keeps insertion order (the `../` rebase is a Rust-side
+    // extension with no C++ reference; lexicographic ordering applies only to
+    // children within a group).
     assert!(expect_ui_group(&out.ui, root_children[0], UiGroupKind::Horizontal, "Foo").is_empty());
     let bar_children = expect_ui_group(&out.ui, root_children[1], UiGroupKind::Vertical, "Bar");
     assert_eq!(bar_children.len(), 1);

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -163,16 +163,22 @@ pub enum ControlKind {
 /// deterministic ordering, trimmed keys/values, and duplicate coalescing.
 pub type UiMetadata = Vec<(String, String)>;
 
-/// Extracts the numeric ordering key from widget/group metadata.
+/// Builds the C++-parity ordering key for one widget/group: the label with
+/// its numeric ordering prefix restored (`[n] label`).
 ///
-/// Faust labels encode display order as a bare integer key, e.g. `[0:]`,
-/// `[1:]`. The C++ compiler uses this to sort items within a group; faust-rs
-/// must do the same to produce matching JSON output.
-pub fn ordering_key_from_metadata(metadata: &UiMetadata) -> i64 {
-    metadata
-        .iter()
-        .find_map(|(key, _)| key.parse::<i64>().ok())
-        .unwrap_or(i64::MAX)
+/// The C++ compiler sequences each group's children by plain byte-wise
+/// comparison of the RAW label — the `[n] ` prefix included — so `"[10]"`
+/// sorts before `"[2]"`, and unnumbered labels interleave by their own
+/// spelling (verified against C++ faust JSON output). The numeric prefix is
+/// parsed into a digits-only metadata key with an empty value during label
+/// splitting, so it can be reconstructed here for ordering purposes.
+pub fn ordering_key_from_label(label: &str, metadata: &UiMetadata) -> String {
+    for (key, value) in metadata {
+        if value.is_empty() && !key.is_empty() && key.bytes().all(|byte| byte.is_ascii_digit()) {
+            return format!("[{key}] {label}");
+        }
+    }
+    label.to_owned()
 }
 
 /// Numeric range metadata for slider-like controls.
@@ -577,7 +583,7 @@ impl<'a> UiBuilder<'a> {
 enum UiDraftNode {
     Group {
         spec: UiGroupSpec,
-        children: Vec<(i64, usize)>, // (order_key, node_id)
+        children: Vec<(String, usize)>, // (order_key, node_id)
     },
     InputControl(ControlId),
     OutputControl(ControlId),
@@ -664,7 +670,7 @@ impl UiProgramBuilder {
         &mut self,
         path: &[UiGroupSpec],
         control: ControlId,
-        order_key: i64,
+        order_key: String,
     ) {
         self.insert_leaf(path, UiDraftNode::InputControl(control), order_key);
     }
@@ -674,13 +680,18 @@ impl UiProgramBuilder {
         &mut self,
         path: &[UiGroupSpec],
         control: ControlId,
-        order_key: i64,
+        order_key: String,
     ) {
         self.insert_leaf(path, UiDraftNode::OutputControl(control), order_key);
     }
 
     /// Inserts one soundfile control under the provided canonical group path.
-    pub fn insert_soundfile(&mut self, path: &[UiGroupSpec], control: ControlId, order_key: i64) {
+    pub fn insert_soundfile(
+        &mut self,
+        path: &[UiGroupSpec],
+        control: ControlId,
+        order_key: String,
+    ) {
         self.insert_leaf(path, UiDraftNode::Soundfile(control), order_key);
     }
 
@@ -697,7 +708,7 @@ impl UiProgramBuilder {
         (arena, roots)
     }
 
-    fn insert_leaf(&mut self, path: &[UiGroupSpec], leaf: UiDraftNode, order_key: i64) {
+    fn insert_leaf(&mut self, path: &[UiGroupSpec], leaf: UiDraftNode, order_key: String) {
         let parent = self.ensure_group_path(path);
         let id = self.push_node(leaf);
         self.insert_child_sorted(parent, order_key, id);
@@ -707,7 +718,7 @@ impl UiProgramBuilder {
         if let Some(existing) = self.find_child_group(parent, &spec) {
             return existing;
         }
-        let order_key = ordering_key_from_metadata(&spec.metadata);
+        let order_key = ordering_key_from_label(&spec.label, &spec.metadata);
         let id = self.push_node(UiDraftNode::Group {
             spec,
             children: Vec::new(),
@@ -769,11 +780,11 @@ impl UiProgramBuilder {
     /// Inserts `child_id` into `parent`'s children list keeping the list
     /// sorted by `order_key`. Items with equal keys are appended after
     /// existing items with the same key (stable / insertion-order tiebreak).
-    fn insert_child_sorted(&mut self, parent: Option<usize>, order_key: i64, child_id: usize) {
+    fn insert_child_sorted(&mut self, parent: Option<usize>, order_key: String, child_id: usize) {
         match parent {
             Some(id) => {
                 if let UiDraftNode::Group { children, .. } = &mut self.nodes[id] {
-                    let pos = children.partition_point(|(k, _)| *k <= order_key);
+                    let pos = children.partition_point(|(k, _)| k.as_str() <= order_key.as_str());
                     children.insert(pos, (order_key, child_id));
                 } else {
                     panic!("parent must be a group");

--- a/crates/ui/tests/core_api.rs
+++ b/crates/ui/tests/core_api.rs
@@ -348,9 +348,9 @@ fn ui_program_builder_merges_group_paths_and_preserves_leaf_order() {
             metadata: Vec::new(),
         },
     ];
-    builder.insert_input_control(&path, 0, i64::MAX);
-    builder.insert_output_control(&path, 1, i64::MAX);
-    builder.insert_soundfile(&path, 2, i64::MAX);
+    builder.insert_input_control(&path, 0, String::new());
+    builder.insert_output_control(&path, 1, String::new());
+    builder.insert_soundfile(&path, 2, String::new());
 
     let (arena, roots) = builder.finish();
     assert_eq!(roots.len(), 1);
@@ -412,7 +412,7 @@ fn ui_program_builder_can_drop_empty_group_placeholders() {
     let bar_id = builder
         .ensure_group_path(&bar)
         .expect("terminal Bar placeholder should exist");
-    builder.insert_input_control(&bar, 0, i64::MAX);
+    builder.insert_input_control(&bar, 0, String::new());
 
     assert!(builder.group_has_children(foo_id));
     assert!(builder.group_has_children(bar_id));

--- a/crates/wasm-ffi/build.rs
+++ b/crates/wasm-ffi/build.rs
@@ -95,6 +95,28 @@ fn collect_library_sources_from_roots(
 fn collect_library_sources(root: &Path) -> Result<Vec<(String, String)>, std::io::Error> {
     let mut files = Vec::new();
     collect_library_files(root, root, &mut files)?;
+    // Mirror the C++ faust wasmlib packaging, which flattens
+    // `libraries/*.lib`, `libraries/dx7/*.lib`, and `libraries/old/*.lib`
+    // into one directory: alias dx7/ and old/ entries under their bare file
+    // names so for example `library("dx7.lib")` (used by stdfaust's `dx`
+    // environment) resolves. Top-level names win on collision; other
+    // subdirectories (for example `unsupported/`) are intentionally not
+    // flattened.
+    let mut aliases: Vec<(String, String)> = Vec::new();
+    for (logical, source) in &files {
+        let Some((dir, bare)) = logical.split_once('/') else {
+            continue;
+        };
+        if !matches!(dir, "dx7" | "old") || bare.contains('/') {
+            continue;
+        }
+        if !files.iter().any(|(existing, _)| existing == bare)
+            && !aliases.iter().any(|(existing, _)| existing == bare)
+        {
+            aliases.push((bare.to_owned(), source.clone()));
+        }
+    }
+    files.extend(aliases);
     files.sort_by(|(left, _), (right, _)| left.cmp(right));
     Ok(files)
 }

--- a/crates/wasm-ffi/src/lib.rs
+++ b/crates/wasm-ffi/src/lib.rs
@@ -176,6 +176,22 @@ impl ResultRegistryText {
 /// without a host filesystem.
 /// Build a `VirtualSourceMap` from the embedded stdlib bundle extended with
 /// any `--virtual-source name=base64` entries found in `argv`.
+/// Builds the compiler for one helper request, honoring `-pn <name>`
+/// (process entry-point selection — e.g. `-pn effect` compiles the
+/// `effect =` declaration, matching the C++ compiler's option).
+fn compiler_with_process_name_from_argv(argv: &[String]) -> Compiler {
+    let process_name = argv
+        .iter()
+        .position(|arg| arg == "-pn")
+        .and_then(|position| argv.get(position + 1))
+        .cloned();
+    let compiler = Compiler::new();
+    match process_name {
+        Some(process_name) => compiler.with_process_name(process_name),
+        None => compiler,
+    }
+}
+
 fn virtual_sources_from_argv(argv: &[String]) -> VirtualSourceMap {
     let mut vsources = embedded_standard_library_sources();
     let mut i = 0;
@@ -798,8 +814,8 @@ pub unsafe extern "C" fn faust_wasm_generate_aux_files(
         Ok(args) => args,
         Err(_) => return 0,
     };
-    let compiler = Compiler::new();
     let argv = split_faustwasm_args(args);
+    let compiler = compiler_with_process_name_from_argv(&argv);
     match compiler.generate_aux_files(&compiler::GenerateAuxFilesRequest {
         source_name: name.to_owned(),
         source: source.to_owned(),
@@ -859,8 +875,8 @@ pub unsafe extern "C" fn faust_wasm_generate_aux_files_json(
             Ok(args) => args,
             Err(error) => return store_text_result(StoredTextResult::Err(error)),
         };
-        let compiler = Compiler::new();
         let argv = split_faustwasm_args(args);
+        let compiler = compiler_with_process_name_from_argv(&argv);
         match compiler.generate_aux_files(&compiler::GenerateAuxFilesRequest {
             source_name: name.to_owned(),
             source: source.to_owned(),

--- a/crates/xtask/src/wasm.rs
+++ b/crates/xtask/src/wasm.rs
@@ -63,6 +63,15 @@ pub(crate) fn build_faustwasm_compiler_module(
     if options.release {
         cargo.arg("--release");
     }
+    // The Rust default wasm shadow stack is 1 MiB, which deep evaluator /
+    // propagation recursion overflows on large real-world DSPs (for example
+    // master_me-class mastering chains). Match a desktop-like 16 MiB stack.
+    let mut rustflags = std::env::var("RUSTFLAGS").unwrap_or_default();
+    if !rustflags.is_empty() {
+        rustflags.push(' ');
+    }
+    rustflags.push_str("-C link-arg=-zstack-size=16777216");
+    cargo.env("RUSTFLAGS", rustflags);
 
     let status = cargo.status()?;
     if !status.success() {


### PR DESCRIPTION
## Summary

Adds an AssemblyScript (`-lang asc`) backend, wires it through the CLI and the `wasm-ffi` compiler module's `generateAuxFiles`, and fixes three C++-parity issues in UI/widget handling that the new backend's real-world validation surfaced (DX7 voices, chorus/mastering effects, compiled and rendered end-to-end from a browser-style host). Based on `main-dev`.

## AssemblyScript backend (`crates/codegen/src/backends/asc/`)

- `generate_asc_module()` modeled on the cpp backend and the C++ asc backend's output shape: `export class`, `this.`/`ClassName.` field access from FIR `AccessType`, `StaticArray<T>`, bare float literals, constant tables as `static` class members.
- Unsuffixed float math names resolve to the f32 intrinsics (`min<f32>`, `Mathf.*`): FAUST_FLOAT is f32 in single precision; C++ narrows doubles implicitly but AssemblyScript raises AS200 on every f64→f32 assignment. Matches the reference C++ asc output.
- Methods are emitted in the C++ `produceClass` order — definitions before the synthesized `instanceInit`/`init` that call them (downstream tooling extracts method bodies by first textual occurrence of `name(`).
- Optional `getJSON(): string` snapshot rendered from the strict C++-style JSON description, mirroring the C++ asc backend.
- CLI: `-lang asc` wired in `cli/args.rs` / `cli/runner.rs` (fixture and real-`.dsp` paths), following the Julia backend's pattern.

## faustwasm compiler-module support

- `generate_aux_files()` recognizes faustwasm-style transpile requests: `-lang asc` produces one AssemblyScript source artifact (honoring `-cn` / `-o`, with `request.virtual_sources` supplying in-memory libraries). Flag-driven outputs (`-cpp`/`-c`/`-wasm`/`-json`/`-svg`) unchanged.
- `-pn <name>` in `faust_wasm_generate_aux_files[_json]` args selects the process entry point via `Compiler::with_process_name` (`-pn effect` compiles the `effect =` declaration like the C++ compiler).
- build.rs flattens `dx7/*.lib` and `old/*.lib` into bare-name aliases in the embedded bundle, mirroring the C++ wasmlib packaging so `library("dx7.lib")` resolves.
- xtask builds the module with a 16 MiB shadow stack (the 1 MiB default overflows on deep evaluator recursion for large DSPs).

## C++-parity fixes

1. **UI child ordering.** The C++ compiler orders each group's children by byte-wise comparison of the raw label including the `[n] ` ordering prefix (`"[10]"` sorts before `"[2]"`; unnumbered labels interleave by their own spelling — verified against faust 2.83 JSON output). The previous numeric-key sort produced a different sequence; since widget enumeration order is what downstream parameter numbering builds on, 138 of 144 DX7 parameter positions differed from the C++ JSON. The ordering key is now the reconstructed raw label (`ordering_key_from_label`). The Rust-side `../` group-rebase extension keeps its root-forest insertion order (C++ has no reference for it — it emits such labels literally).

2. **Widget identity: control aliasing scoped to AD seeds.** `register_control` aliased ANY re-registration of a widget box under a different group context to its first ControlId. That collapsed widgets C++ treats as distinct: in `par(i, N, vgroup("Op %i", hslider("g", ...)))` the same box under N interpolated group instances must yield N controls with N DSP fields. A DX7 voice wired only 34 of its 147 parameters into the signal path (repeated per-operator envelope parameters all aliased to operator 1), leaving envelopes at init values — audibly collapsing a piano patch into a percussive thump — while the UI description still listed all 147 parameters. The alias is kept for its original purpose: boxes referenced from a `ForwardAD`/`ReverseAD` seed subtree are marked as differentiation parameters and only those alias across contexts (in both directions, so body references appearing after the seed unify too). `fad_recursive_deep_{right,left,both}` keep their single shared control.

3. **Const-table placement.** Compile-time constant tables are emitted as `static` class members in the asc backend so qualified `ClassName.table` references resolve, mirroring the C++ asc backend.

## Regression tests

- `replicated_widgets_wire_distinct_dsp_fields` — generated code must contain three DSP fields for three group instances (UI-level checks cannot see this failure mode).
- `ad_seed_references_unify_to_one_control` — a fad-seed-referenced widget resolves to one control across body/seed contexts.
- `identical_widgets_under_distinct_groups_stay_distinct` — JSON has all three addresses.
- `ui_children_sort_lexicographically_by_raw_label` — pins the raw-label sort rule (`Aa` < `[10] b` < `[2] a` < `zz`).
- asc `-lang asc` aux-file generation test + backend unit tests.

## Validation

- 8/8 FIR fixtures and real-world DSPs (DX7 algorithms via `dx.algorithm`, a chorus via `--virtual-source` + `-pn effect`, a mastering chain) compile through the real `asc` compiler (`--runtime stub`) with 0 errors, end-to-end from Node against the built wasm module.
- DX7 parameter JSON is sequence-identical to C++ faust (147/147 addresses); 127 slider DSP fields, matching the C++ compiler.
- Rendered audio verified downstream (sustained, pitch-stable DX7 E.Piano note through an in-browser transpile → AssemblyScript → wasm → WAV pipeline).
- Full workspace suite: 1390 passed, 0 new failures (the 24 autodiff runtime failures also occur on pristine `main-dev` in this environment — they need installed Faust libraries). Clippy clean.