### PR TITLE
docs(journal): retroactive entry for the asc backend implementation

### DIFF
--- a/porting/journal/2026-06-10.md
+++ b/porting/journal/2026-06-10.md
@@ -490,3 +490,52 @@ Changes:
 Validation:
 
 - documentation-only update.
+
+## Add the AssemblyScript (`-lang asc`) backend
+
+Commit date: 2026-06-10
+Source commit: c04c1bd (backend); e200e41, dfda38d (generateAuxFiles
+path); e3936d9 (C++-shape parity + widget-identity regression test)
+
+Retroactive entry: the `asc` backend implementation landed without its own
+journal entry (only the later README documentation pass, above, was
+recorded). This entry documents the implementation from Git history.
+
+New backend that lowers FIR `Module` roots to AssemblyScript, mirroring the
+C++ Faust AssemblyScript backend and following the workspace's `cpp` backend
+structure.
+
+C++ reference: `RUST/faust`, branch `master-dev-ocpp-od-fir-2-FIR19`,
+commit `8eebea429`:
+- `compiler/generator/assemblyscript/assemblyscript_instructions.hh`
+- `compiler/generator/assemblyscript/assemblyscript_code_container.cpp`
+
+Implementation updates:
+
+- new `crates/codegen/src/backends/asc/mod.rs` (~1.25k lines) exposing
+  `generate_asc_module` and `AscOptions` (`class_name`, `quad_type_name`,
+  `fixed_type_name`, `json`); module-level `//!` Rustdoc records the C++
+  provenance, the output contract, and the scalar-only limitation;
+- output contract: `export class <name>`, instance state as `this.<field>`
+  and static struct fields as `<ClassName>.<field>`, cast-wrapped numeric
+  literals (`<i32>`/`<f32>`/`<f64>`), `StaticArray<T>`, `Math.*`/`Mathf.*`
+  math dispatch, UI / soundfile nodes emitted as comments (parity with the
+  C++ asc backend), optional embedded `getJSON(): string`;
+- CLI wiring (`crates/compiler/src/cli/args.rs`, `runner.rs`,
+  `crates/codegen/src/backends/mod.rs`): `CliLang::Asc` + `-lang asc` on both
+  the `--fir-fixture` and real-`.dsp` paths;
+- `generateAuxFiles` support for faustwasm transpile requests
+  (`-lang asc`, `-pn` process selection) via `generate_asc_aux_file`, with
+  the `CompilerError` re-mapped to `FaustwasmServiceError`;
+- error codes `FRS-CGEN-ASC-0001..0003`; unsupported FIR nodes fail fast with
+  `FRS-CGEN-ASC-0003`;
+- backend documented in `crates/codegen/README.md` and `README.md`
+  (`faust-rs -lang asc foo.dsp`).
+
+Validation:
+
+- 3 backend unit tests plus a widget-identity regression test in
+  `asc/mod.rs`; full codegen + compiler suites green; `cargo clippy
+  --workspace --all-targets -- -D warnings` clean; no `unsafe` introduced;
+- generated AssemblyScript compiles to wasm via `asc` (AssemblyScript 0.27)
+  with zero errors on representative corpus DSPs.


### PR DESCRIPTION
## Summary

The AssemblyScript (`-lang asc`) backend landed (`c04c1bd` and follow-ups) without its own `porting/journal/` entry — only the later README documentation pass was recorded. This adds the implementation entry, generated from Git history, per AGENTS.md §5 and §11.

The entry cites the source commits, the C++ provenance (`assemblyscript_instructions.hh` / `assemblyscript_code_container.cpp`), the output contract, error codes (`FRS-CGEN-ASC-0001..0003`), and validation. It is placed at the end of the day file because the implementation commits (22:39) predate the already-recorded README-doc entry (23:14), consistent with the most-recent-at-top ordering rule.

## Validation

- Documentation-only change.
- Verified on main (post-merge): `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --all-targets`, and `cargo run -p xtask -- golden-check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)