### PR TITLE
perf(tlib): single-allocate children on the arity-≥3 intern path

### DIFF
--- a/crates/tlib/src/arena.rs
+++ b/crates/tlib/src/arena.rs
@@ -73,7 +73,12 @@ pub enum ChildList {
     /// Two children, inline.
     Two([TreeId; 2]),
     /// Three or more children on heap.
-    Many(Box<[TreeId]>),
+    ///
+    /// Stored as `Arc<[TreeId]>` so the single allocation made when a node is
+    /// first interned is shared with the hash-cons key in
+    /// [`TreeArena::intern`] (one allocation per new arity-`>= 3` node instead
+    /// of two).
+    Many(Arc<[TreeId]>),
 }
 
 impl ChildList {
@@ -98,7 +103,7 @@ impl ChildList {
     /// Creates a generic arity list (`>= 0`) from heap-backed storage.
     #[must_use]
     pub fn many(children: Vec<TreeId>) -> Self {
-        Self::Many(children.into_boxed_slice())
+        Self::Many(children.into())
     }
 
     /// Number of children.
@@ -144,7 +149,7 @@ impl ChildList {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct NodeKey {
     kind: NodeKind,
-    children: Vec<TreeId>,
+    children: Arc<[TreeId]>,
 }
 
 /// Bidirectional `&str ↔ u32` interner.
@@ -356,9 +361,13 @@ impl TreeArena {
                 id
             }
             _ => {
+                // Allocate the children slice once and share it (refcounted)
+                // between the hash-cons key and the stored node, so a new
+                // arity-`>= 3` node costs one heap allocation rather than two.
+                let children: Arc<[TreeId]> = Arc::from(children);
                 let key = NodeKey {
                     kind,
-                    children: children.to_vec(),
+                    children: Arc::clone(&children),
                 };
                 if let Some(id) = self.interner_n.get(&key) {
                     return *id;
@@ -366,7 +375,7 @@ impl TreeArena {
                 let id = TreeId(self.nodes.len() as u32);
                 self.nodes.push(TreeNode {
                     kind: key.kind.clone(),
-                    children: ChildList::many(key.children.clone()),
+                    children: ChildList::Many(children),
                 });
                 self.interner_n.insert(key, id);
                 id

--- a/crates/tlib/tests/core_semantics.rs
+++ b/crates/tlib/tests/core_semantics.rs
@@ -23,6 +23,45 @@ fn interning_reuses_structurally_identical_nodes() {
     assert_eq!(seq1, seq2);
 }
 
+/// Structural non-regression for the arity-`>= 3` intern path.
+///
+/// This path stores children as a single `Arc<[TreeId]>` shared between the
+/// hash-cons key and the stored node. The test guards that hash-consing still
+/// deduplicates structurally identical high-arity nodes, that children round
+/// trip unchanged, and that differing children still produce distinct nodes.
+#[test]
+fn interning_high_arity_nodes_shares_and_dedups_children() {
+    let mut arena = TreeArena::new();
+    let seq_tag = arena.intern_tag("seq");
+
+    // Build two structurally identical arity-4 nodes from independently
+    // interned (but equal) children.
+    let first: Vec<_> = ["a", "b", "c", "d"]
+        .iter()
+        .map(|s| arena.symbol(*s))
+        .collect();
+    let second: Vec<_> = ["a", "b", "c", "d"]
+        .iter()
+        .map(|s| arena.symbol(*s))
+        .collect();
+    assert_eq!(first, second, "equal symbols must intern to equal ids");
+
+    let node1 = arena.intern(NodeKind::Tag(seq_tag), &first);
+    let node2 = arena.intern(NodeKind::Tag(seq_tag), &second);
+    assert_eq!(
+        node1, node2,
+        "structurally identical arity-4 nodes must share an id"
+    );
+
+    // Children must round trip exactly through the shared storage.
+    assert_eq!(arena.children(node1), Some(first.as_slice()));
+
+    // A differing child list must produce a distinct node.
+    let e = arena.symbol("e");
+    let other = arena.intern(NodeKind::Tag(seq_tag), &[first[0], first[1], first[2], e]);
+    assert_ne!(node1, other, "differing children must not be deduplicated");
+}
+
 #[test]
 fn list_operations_preserve_head_and_tail_order() {
     let mut arena = TreeArena::new();


### PR DESCRIPTION
## Summary

`TreeArena::intern` allocated the children slice **twice** for every new arity-≥3 node:

1. `children.to_vec()` to build the hash-cons `NodeKey`, then
2. `key.children.clone()` to build the stored `TreeNode`.

Every node construction in the compiler flows through `intern`, so this is the hottest allocation path in the whole pipeline — and AGENTS.md §8 explicitly flags TreeArena performance as a standing regression risk.

## Change

Store children as `Arc<[TreeId]>` in both [`ChildList::Many`](crates/tlib/src/arena.rs) and the internal `NodeKey`, build the slice once in the arity-≥3 arm, and share it (refcounted) between the interner key and the node.

- **New arity-≥3 node:** 1 heap allocation instead of 2.
- **Cache hit:** unchanged — one temporary lookup key, exactly as before (`to_vec()` → `Arc::from`).
- **Correctness:** `Arc<[T]>` compares and hashes by slice contents, so structural hash-consing semantics are identical. `ChildList` has no consumers outside `tlib`, so the `Box`→`Arc` representation change is internal.

## Tests

Added a structural non-regression test (`interning_high_arity_nodes_shares_and_dedups_children`) for the arity-≥3 path: dedup of structurally identical high-arity nodes, exact children round-trip through the shared storage, and distinctness under differing children.

## Validation

`cargo fmt --all` · `cargo clippy --workspace --all-targets -- -D warnings` · `cargo test --workspace --all-targets` · `cargo run -p xtask -- golden-check` — all green.

## Follow-up (not in this PR)

`clone_rec` (cross-arena clone) still builds a `Vec` per node before calling `intern`, including for arity 0/1/2 where `intern` then uses the inline path. That's a separate, larger change (it would touch `intern`'s `&[TreeId]` signature) and is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)