### PR TITLE
ci: resolve stdfaust.lib in Lint and test via pinned faustlibraries checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,12 @@ jobs:
     name: Lint and test (${{ matrix.os }})
     needs: check
     runs-on: ${{ matrix.os }}
+    env:
+      # The vector-mode regression corpus imports `stdfaust.lib`; the compiler
+      # resolves it from FAUST_LIB_PATH first. Point it at the pinned Faust
+      # standard-library checkout added below. Unlike `apt-get install faust`,
+      # a git checkout works on all three runner OSes.
+      FAUST_LIB_PATH: ${{ github.workspace }}/faustlibraries
     strategy:
       fail-fast: false
       matrix:
@@ -48,6 +54,13 @@ jobs:
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+
+      - name: Check out the Faust standard libraries
+        uses: actions/checkout@v4
+        with:
+          repository: grame-cncm/faustlibraries
+          ref: ecf2fdc238148c44c18352102333a1229ca7a8d3
+          path: faustlibraries
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/crates/transform/src/signal_fir/module/state.rs
+++ b/crates/transform/src/signal_fir/module/state.rs
@@ -483,7 +483,12 @@ impl<'a> SignalToFirLower<'a> {
         let init_name = format!("{name}Init");
         let init_decl = {
             let mut b = FirBuilder::new(&mut self.store);
-            b.declare_table(init_name.clone(), AccessType::Static, elem_ty.clone(), values)
+            b.declare_table(
+                init_name.clone(),
+                AccessType::Static,
+                elem_ty.clone(),
+                values,
+            )
         };
         self.sections.static_declarations.push(init_decl);
 

--- a/crates/transform/src/signal_fir/module/tables.rs
+++ b/crates/transform/src/signal_fir/module/tables.rs
@@ -265,12 +265,7 @@ impl<'a> SignalToFirLower<'a> {
             &generated,
         );
         self.sections.struct_declarations.push(decl);
-        self.register_constant_table_init(
-            name.clone(),
-            AccessType::Struct,
-            elem_ty,
-            &generated,
-        );
+        self.register_constant_table_init(name.clone(), AccessType::Struct, elem_ty, &generated);
         self.ui.waveform_tables.insert(sig, name.clone());
         self.ui.waveform_table_len.insert(sig, size);
         self.ui.table_access_by_sig.insert(sig, AccessType::Struct);


### PR DESCRIPTION
Makes the `Lint and test` CI job green again. Two independent, pre-existing
failures on `main` block it; this PR fixes both.

## 1. `stdfaust.lib` cannot be resolved (the karplus regression)

`karplus_pass_through_backedge_is_certified_and_bit_exact`
(`crates/compiler/tests/vector_mode.rs`) compiles a DSP that
`import("stdfaust.lib")`. The `Lint and test` job never provided the Faust
standard libraries, so the test failed on all three runner OSes with
`cannot resolve import stdfaust.lib`.

Fix: point `FAUST_LIB_PATH` — the compiler's first import search path
(`crates/compiler/src/paths.rs`) — at a pinned checkout of
`grame-cncm/faustlibraries`, added as a second `actions/checkout` step.
`apt-get install faust` (used by the ubuntu-only `Checked vector retention`
job) cannot be reused here: `Lint and test` runs on ubuntu, macOS **and**
windows, and a git checkout is the only cross-platform option. Pinned to a
SHA (`ecf2fdc2`, 2026-07-08) for reproducibility.

Verified locally: with `FAUST_LIB_PATH` pointed at this pinned checkout the
karplus regression passes (it transitively pulls `physmodels.lib` /
`maths.lib`, so the checkout is exercised as a complete library set).

## 2. `cargo fmt` is red on main

Commit `21571f0d` ("Loop-copy large constant table init instead of
unrolling it") left two call sites in `signal_fir/module/{state,tables}.rs`
unformatted, so `Lint and test` fails at the formatting step before any
test runs. A pure rustfmt reflow of those two sites (no behavior change) is
included here so the gate passes and the faustlibraries checkout above is
actually exercised by the test step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
