### PR TITLE
fix(fir): cap dump_fir indentation so deep trees stay O(n) (fixes Windows OOM)

### DIFF
--- a/crates/fir/src/dump.rs
+++ b/crates/fir/src/dump.rs
@@ -108,6 +108,14 @@ fn write_canonical_kind(store: &FirStore, kind: &NodeKind, out: &mut String) {
     }
 }
 
+/// Visual indentation is capped at this depth. Otherwise a chain whose depth
+/// is linear in program size (`Cons` list spines, deep recursion) would emit
+/// `depth` indentation bytes on every line, making the whole dump Θ(depth²) in
+/// size — a 100k-deep tree builds a multi-gigabyte string. Nodes deeper than
+/// the cap reuse the capped indent and print their exact depth numerically, so
+/// the dump stays O(n) without losing depth information.
+const MAX_DUMP_INDENT: usize = 40;
+
 // Iterative for the same stack-depth reason as `fingerprint_node`.
 fn dump_node(
     store: &FirStore,
@@ -118,9 +126,13 @@ fn dump_node(
 ) {
     let mut stack = vec![(root, depth)];
     while let Some((id, depth)) = stack.pop() {
-        let indent = "  ".repeat(depth);
         let node = match_fir(store, id);
-        let _ = writeln!(out, "{indent}#{} {:?}", id.as_u32(), node);
+        let indent = "  ".repeat(depth.min(MAX_DUMP_INDENT));
+        if depth <= MAX_DUMP_INDENT {
+            let _ = writeln!(out, "{indent}#{} {:?}", id.as_u32(), node);
+        } else {
+            let _ = writeln!(out, "{indent}[depth {depth}] #{} {:?}", id.as_u32(), node);
+        }
         if !seen.insert(id) {
             continue;
         }


### PR DESCRIPTION
Fixes the intermittent red on the Windows `Lint and test` lane by making
`dump_fir` linear in output size, per @sletz's preference to fix the walker
rather than the test.

## Root cause

`dump_and_fingerprint_survive_deep_trees_on_small_stacks` (added in `26e76808`)
builds a 100,000-deep `neg` chain and runs both dump walkers over it. The
traversal is already iterative, so it does not overflow the stack — the problem
is the **output size**:

- `canonical_fir_fingerprint` emits one line per distinct node → Θ(n). Fine.
- `dump_fir` prepends `"  ".repeat(depth)` to every line, so a chain of depth
  *d* emits Σ 2·depth ≈ **Θ(d²)** bytes. At d = 100k that is ~10 GB of text;
  when the backing `String` doubles it requests **2³⁴ = 16 GiB exactly**.

Linux/macOS tolerate the allocation through memory overcommit; Windows (no
overcommit) aborts with `memory allocation of 17179869184 bytes failed` /
`STATUS_STACK_BUFFER_OVERRUN`. It sits right at the runner's commit limit, so it
presents as a flaky Windows failure. Unrelated to #8 (which never touched `fir`).

## How `dump_fir` is made O(n)

The quadratic cost is entirely in the per-line indentation prefix. Cap the
visual indentation at a constant (`MAX_DUMP_INDENT = 40` levels); nodes deeper
than the cap reuse the capped indent and print their exact depth numerically
(`[depth 12345] #id …`). Per-line prefix becomes O(1), so the whole dump is
O(n), and no depth information is lost.

```
        …  #987 Neg { … }
        …  [depth 41] #986 Neg { … }
        …  [depth 42] #985 Neg { … }
```

The 100k regression test is left **exactly as written** (it now exercises the
fixed walker); no test was weakened.

## Verification

- The 100k regression passes in ~0.4 s at ~280 MB peak RSS (was >16 GiB).
- Full `fir` suite green (106 tests); `fmt`/`clippy` clean.
- Existing `dump_fir` tests assert on node/kind substrings, not indentation, so
  the numeric-depth format past the cap is compatible.

Draft — flagged for review of the cap value / format before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
