### PR TITLE
Honor -ec/-os execution flags in the faustwasm generateAuxFiles argv

### DIFF
--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -374,6 +374,7 @@ pub struct FirVerifyOptions {
 ///
 /// Current canonical flow:
 /// `parse -> eval -> propagate -> (optional signal->FIR lowering) -> codegen`.
+#[derive(Clone)]
 pub struct Compiler {
     fir_verify: FirVerifyOptions,
     entrypoint_name: Box<str>,
@@ -1674,6 +1675,22 @@ impl Compiler {
     ///
     /// Additionally, faustwasm-style transpile requests using `-lang asc`
     /// produce one AssemblyScript source artifact (honoring `-cn` and `-o`).
+    /// Returns a derived compiler with the execution-option flags found in a
+    /// faustwasm-style argv applied (`-ec`/`--ec`/`--external-control`/
+    /// `--ext-control` and `-os`/`--os`/`--one-sample`), matching the CLI
+    /// flag spellings.
+    fn with_execution_options_from_argv(&self, argv: &[String]) -> Compiler {
+        let has = |names: &[&str]| argv.iter().any(|arg| names.contains(&arg.as_str()));
+        let mut compiler = self.clone();
+        if has(&["-ec", "--ec", "--external-control", "--ext-control"]) {
+            compiler = compiler.with_control_rate_mode(ControlRateMode::External);
+        }
+        if has(&["-os", "--os", "--one-sample"]) {
+            compiler = compiler.with_processing_api(ProcessingApi::OneSample);
+        }
+        compiler
+    }
+
     pub fn generate_aux_files(
         &self,
         request: &GenerateAuxFilesRequest,
@@ -1682,12 +1699,17 @@ impl Compiler {
         let search_paths = parse_search_paths_from_argv(&argv);
         let double = argv.iter().any(|a| a == "-double");
 
+        // Execution options travel in the same argv string; a derived
+        // compiler applies them so downstream compile calls validate them
+        // instead of silently ignoring the flags.
+        let compiler = self.with_execution_options_from_argv(&argv);
+
         // faustwasm-style transpile request: `-lang asc` produces one
         // AssemblyScript source artifact instead of the flag-driven outputs.
         if let Some(position) = argv.iter().position(|arg| arg == "-lang")
             && argv.get(position + 1).map(String::as_str) == Some("asc")
         {
-            return self.generate_asc_aux_file(request, &argv, &search_paths);
+            return compiler.generate_asc_aux_file(request, &argv, &search_paths);
         }
 
         let wants_cpp = argv.iter().any(|a| a == "-cpp");
@@ -1703,7 +1725,7 @@ impl Compiler {
             .unwrap_or("process");
 
         if wants_cpp {
-            let cpp = self
+            let cpp = compiler
                 .compile_source_to_cpp(
                     &request.source_name,
                     &request.source,
@@ -1718,7 +1740,7 @@ impl Compiler {
         }
 
         if wants_c {
-            let c = self
+            let c = compiler
                 .compile_source_to_c(&request.source_name, &request.source, &COptions::default())
                 .map_err(|e| FaustwasmServiceError::unsupported(e.to_string()))?;
             artifacts.push(AuxFileArtifact {
@@ -1733,7 +1755,7 @@ impl Compiler {
                 double_precision: double,
                 ..Default::default()
             };
-            let wasm = self
+            let wasm = compiler
                 .compile_source_to_wasm(&request.source_name, &request.source, &opts)
                 .map_err(|e| FaustwasmServiceError::unsupported(e.to_string()))?;
             artifacts.push(AuxFileArtifact {
@@ -1747,7 +1769,7 @@ impl Compiler {
                 binary: false,
             });
         } else if wants_json {
-            let json = self
+            let json = compiler
                 .compile_source_to_json(&request.source_name, &request.source)
                 .map_err(|e| FaustwasmServiceError::unsupported(e.to_string()))?;
             artifacts.push(AuxFileArtifact {
@@ -1758,7 +1780,7 @@ impl Compiler {
         }
 
         if wants_svg {
-            let signals = self
+            let signals = compiler
                 .compile_source_to_signals_with_import_context(
                     &request.source_name,
                     &request.source,

--- a/crates/compiler/tests/execution_options.rs
+++ b/crates/compiler/tests/execution_options.rs
@@ -179,6 +179,46 @@ fn asc_shapes_match_the_one_sample_contract() {
 }
 
 #[test]
+fn faustwasm_aux_files_honor_execution_flags_in_argv() {
+    // The faustwasm `generateAuxFiles` surface receives its options as one
+    // raw argv string; `-ec`/`-os` (and the `--` spellings) must configure
+    // the derived compiler instead of being silently ignored.
+    use compiler::GenerateAuxFilesRequest;
+
+    for flags in ["--ec --os", "-ec -os", "--external-control --one-sample"] {
+        let request = GenerateAuxFilesRequest {
+            source_name: "exec_options_test.dsp".to_owned(),
+            source: SLIDER_GAIN.to_owned(),
+            args: format!("-lang asc -cn ExecTest {flags} -o /exec.out.ts"),
+            ..GenerateAuxFilesRequest::default()
+        };
+        let artifacts = Compiler::new()
+            .generate_aux_files(&request)
+            .expect("asc aux generation must succeed");
+        let asc = String::from_utf8(artifacts[0].content.clone()).expect("utf-8");
+        assert!(asc.contains("control(): void {"), "flags {flags}: {asc}");
+        assert!(
+            asc.contains("frame(inputs: StaticArray<f32>, outputs: StaticArray<f32>): void {"),
+            "flags {flags}"
+        );
+    }
+
+    // Without the flags the classic block contract is untouched.
+    let request = GenerateAuxFilesRequest {
+        source_name: "exec_options_test.dsp".to_owned(),
+        source: SLIDER_GAIN.to_owned(),
+        args: "-lang asc -cn ExecTest -o /exec.out.ts".to_owned(),
+        ..GenerateAuxFilesRequest::default()
+    };
+    let artifacts = Compiler::new()
+        .generate_aux_files(&request)
+        .expect("classic asc aux generation must succeed");
+    let asc = String::from_utf8(artifacts[0].content.clone()).expect("utf-8");
+    assert!(!asc.contains("control(): void {"));
+    assert!(!asc.contains("frame(inputs:"));
+}
+
+#[test]
 fn unsupported_backends_and_vector_mode_still_reject() {
     // -os stays a hard error in vector mode whatever the backend.
     let compiler = Compiler::new()

--- a/porting/journal/2026-07-24.md
+++ b/porting/journal/2026-07-24.md
@@ -389,3 +389,24 @@ non-regression run in background.
   tests and the transform structural tests (adapted).
 - The port is complete end to end: phases 0-6 plus the §5.7
   AssemblyScript one-sample follow-up, all differentials green.
+
+## faustwasm service: execution options in the argv (PR #13)
+
+Consuming the merged `-ec`/`-os` port from the wasm compiler module exposed
+one gap: the faustwasm surface (`generateAuxFiles`) hand-parses its raw argv
+string and never consulted the execution options — `-lang asc -ec -os`
+compiled fine but silently emitted the classic block class (the exact
+silent-flag-ignore hazard the capability table guards against elsewhere).
+Fixed by deriving a per-request `Compiler` (`Clone` added) with
+`-ec/--ec/--external-control/--ext-control` and `-os/--os/--one-sample`
+applied before dispatch, for the asc path and the flag-driven cpp/c/wasm/json
+outputs alike; unsupported combinations now error through the existing
+per-backend validation. Locked by an integration test over all three flag
+spellings plus the classic no-flag shape. Verified end-to-end from Node
+against the rebuilt wasm32 module (note: the module only embeds the standard
+libraries when built with `FAUST_RS_EMBEDDED_LIB_ROOT`).
+
+Downstream (wasm-music, PR petersalomonsen/javascriptmusic#175): the
+1538-line block→one-sample reshape transpiler is replaced by 804 lines of
+thin wrapper codegen around the native `control()`/`frame()` class — the
+first production consumer of the AssemblyScript one-sample target.


### PR DESCRIPTION
## Summary

The faustwasm service surface (`generateAuxFiles`) hand-parses its raw argv string and never consulted the execution options: `-lang asc -ec -os` compiled successfully but silently emitted the classic block-compute class — the exact silent-flag-ignore hazard the capability table was built to prevent.

`Compiler` now derives a per-request instance with `-ec`/`--ec`/`--external-control`/`--ext-control` and `-os`/`--os`/`--one-sample` applied (same spellings as the CLI), used by the asc transpile path and the flag-driven cpp/c/wasm/json outputs alike. Unsupported combinations now surface as errors through the existing per-backend validation instead of being ignored.

## Motivation

This unblocks consuming the native `control()`/`frame()` AssemblyScript output through the wasm compiler module (browser/Node hosts drive the compiler exclusively through this argv string).

## Testing

- New integration test locks `control(): void`/`frame(inputs: StaticArray<f32>, ...)` presence for all three flag spellings, and their absence without flags.
- Rebuilt the wasm32 compiler module and verified end-to-end from Node: `-lang asc -cn X --ec --os` now emits the one-sample class (was: classic block shape).
- `cargo test -p compiler`, workspace clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)