### PR TITLE
Retain structured diagnostics on the helper-service text results

### DIFF
--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -403,6 +403,13 @@ pub struct FaustwasmServiceError {
     pub code: FaustwasmServiceErrorCode,
     /// User-facing explanation intended for JS-side propagation.
     pub message: String,
+    /// Typed compiler diagnostics, retained when the failure came from a
+    /// [`CompilerError`] (the common case: the DSP failed to compile).
+    ///
+    /// `None` for transport/argument failures, which have no compiler
+    /// diagnostic to carry. Host bindings render this through the
+    /// diagnostics-v2 JSON channel instead of re-parsing `message`.
+    pub diagnostics: Option<DiagnosticBundle>,
 }
 
 /// Stable error codes for the helper-service surface.
@@ -428,6 +435,7 @@ impl FaustwasmServiceError {
         Self {
             code: FaustwasmServiceErrorCode::Unsupported,
             message: message.to_string(),
+            diagnostics: None,
         }
     }
 
@@ -437,6 +445,21 @@ impl FaustwasmServiceError {
         Self {
             code: FaustwasmServiceErrorCode::InvalidArgument,
             message: message.to_string(),
+            diagnostics: None,
+        }
+    }
+
+    /// Builds an [`FaustwasmServiceErrorCode::Unsupported`] error that keeps
+    /// the typed compiler diagnostics alongside the rendered message.
+    ///
+    /// Use this — not [`FaustwasmServiceError::unsupported`] — wherever the
+    /// source error is a [`CompilerError`], so host bindings can serve the
+    /// complete diagnostics-v2 report instead of one flattened string.
+    fn compile_failure(error: CompilerError) -> Self {
+        Self {
+            code: FaustwasmServiceErrorCode::Unsupported,
+            message: error.to_string(),
+            diagnostics: Some(error.diagnostic_bundle().clone()),
         }
     }
 }

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -427,10 +427,11 @@ impl FaustwasmServiceError {
     /// Builds an error tagged [`FaustwasmServiceErrorCode::Unsupported`].
     ///
     /// Takes any [`Display`](std::fmt::Display) value so a fallible stage can
-    /// be mapped without a closure: `.map_err(FaustwasmServiceError::unsupported)?`
-    /// works for [`CompilerError`], backend codegen errors, and `draw` errors
-    /// alike. Every compile failure on this surface renders through here, so
-    /// one rendered diagnostic shape reaches the host for all of them.
+    /// be mapped without a closure: `.map_err(FaustwasmServiceError::unsupported)?`.
+    /// Use it for failures that carry no typed compiler diagnostics (backend
+    /// codegen errors, `draw` errors); [`CompilerError`] sources go through
+    /// [`FaustwasmServiceError::compile_failure`] instead so the typed
+    /// [`DiagnosticBundle`] survives to the host bindings.
     fn unsupported(message: impl std::fmt::Display) -> Self {
         Self {
             code: FaustwasmServiceErrorCode::Unsupported,

--- a/crates/compiler/src/service.rs
+++ b/crates/compiler/src/service.rs
@@ -55,7 +55,7 @@ impl Compiler {
             &search_paths,
         )
         .map(|_| request.source.clone())
-        .map_err(FaustwasmServiceError::unsupported)
+        .map_err(FaustwasmServiceError::compile_failure)
     }
 
     /// Returns a copy of this compiler with the compilation options found in a
@@ -168,14 +168,14 @@ impl Compiler {
         if wants("-cpp") {
             let cpp = compiler
                 .compile_source_to_cpp(name, source, &CppOptions::default())
-                .map_err(FaustwasmServiceError::unsupported)?;
+                .map_err(FaustwasmServiceError::compile_failure)?;
             artifacts.push(AuxFileArtifact::text(stem, "cpp", cpp));
         }
 
         if wants("-c") {
             let c = compiler
                 .compile_source_to_c(name, source, &COptions::default())
-                .map_err(FaustwasmServiceError::unsupported)?;
+                .map_err(FaustwasmServiceError::compile_failure)?;
             artifacts.push(AuxFileArtifact::text(stem, "c", c));
         }
 
@@ -188,7 +188,7 @@ impl Compiler {
             };
             let wasm = compiler
                 .compile_source_to_wasm(name, source, &options)
-                .map_err(FaustwasmServiceError::unsupported)?;
+                .map_err(FaustwasmServiceError::compile_failure)?;
             artifacts.push(AuxFileArtifact::binary(stem, "wasm", wasm.wasm_binary));
             artifacts.push(AuxFileArtifact::text(stem, "json", wasm.dsp_json));
         }
@@ -200,7 +200,7 @@ impl Compiler {
         if wants("-json") && !wants("-wasm") {
             let json = compiler
                 .compile_source_to_json(name, source)
-                .map_err(FaustwasmServiceError::unsupported)?;
+                .map_err(FaustwasmServiceError::compile_failure)?;
             artifacts.push(AuxFileArtifact::text(stem, "json", json));
         }
 
@@ -212,7 +212,7 @@ impl Compiler {
                     &search_paths,
                     &request.virtual_sources,
                 )
-                .map_err(FaustwasmServiceError::unsupported)?;
+                .map_err(FaustwasmServiceError::compile_failure)?;
             // Name the diagram "process" so the root file is always
             // process.svg, matching the C++ compiler convention and the
             // faustwasm `FaustSvgDiagrams.from(...)` expectation.
@@ -268,14 +268,14 @@ impl Compiler {
                 search_paths,
                 &request.virtual_sources,
             )
-            .map_err(FaustwasmServiceError::unsupported)?;
+            .map_err(FaustwasmServiceError::compile_failure)?;
         let lowered = self
             .lower_to_fir(
                 &request.source_name,
                 &signals,
                 SignalFirLane::TransformFastLane,
             )
-            .map_err(FaustwasmServiceError::unsupported)?;
+            .map_err(FaustwasmServiceError::compile_failure)?;
 
         let class_name = argv_value(argv, &["-cn"]).map_or_else(
             || sanitize_cpp_ident(source_name_to_class(&request.source_name).as_str()),

--- a/crates/wasm-ffi/README.md
+++ b/crates/wasm-ffi/README.md
@@ -83,6 +83,22 @@ The raw compiler-module ABI is explicitly handle-based:
 9. release the compile result with `faust_wasm_result_free`
 10. release the temporary request buffers with `faust_wasm_dealloc`
 
+Helper text results (`faust_wasm_get_info`, `faust_wasm_expand_dsp`,
+`faust_wasm_generate_aux_files_json`) carry structured diagnostics too: when
+`faust_wasm_text_result_is_ok` returns `0`,
+`faust_wasm_text_result_diagnostics_ptr/len` expose the complete
+diagnostics-v2 report for compiler failures (null/0 for transport and
+argument failures, and on modules predating these exports). The
+compatibility message from `faust_wasm_text_result_ptr/len` is unchanged, so
+hosts adopt the richer payload at their own pace. Host-adapter status:
+
+- WebAssembly Music consumes these exports (structured errors reach its
+  Faust editor, CLI, and LLM studio agent);
+- the `faustwasm` TypeScript adapter (`RustLibFaust` / `FaustCompiler`) does
+  not read them yet — its `readTextResult` frees the handle without querying
+  diagnostics. Wiring `getErrorDiagnostics()`-style accessors for the helper
+  surface there is tracked follow-up work.
+
 Pointer validity rules:
 
 - payload pointers returned by `faust_wasm_result_*_ptr` stay valid only until

--- a/crates/wasm-ffi/src/lib.rs
+++ b/crates/wasm-ffi/src/lib.rs
@@ -97,7 +97,56 @@ struct StoredCompileSuccess {
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum StoredTextResult {
     Ok(String),
-    Err(String),
+    Err {
+        /// Human-readable compatibility message (unchanged legacy payload).
+        message: String,
+        /// Complete diagnostics-v2 JSON report, retained when the failure
+        /// carried typed compiler diagnostics. `None` for transport and
+        /// argument failures.
+        diagnostics_json: Option<String>,
+    },
+}
+
+impl StoredTextResult {
+    /// One error text result with no typed compiler diagnostics.
+    fn err(message: impl Into<String>) -> Self {
+        StoredTextResult::Err {
+            message: message.into(),
+            diagnostics_json: None,
+        }
+    }
+
+    /// Captures a helper-service failure, rendering any retained compiler
+    /// diagnostics as one complete diagnostics-v2 report — the same
+    /// no-presentation-parameter contract as
+    /// [`faust_wasm_result_get_error_diagnostics`].
+    fn from_service_error(
+        error: compiler::FaustwasmServiceError,
+        request: DiagnosticsRequestMetadata,
+    ) -> Self {
+        let diagnostics_json = error.diagnostics.as_ref().map(|bundle| {
+            render_complete_diagnostics_v2_json(
+                bundle,
+                DiagnosticsCompilerMetadata::default(),
+                request,
+                SourceTextPolicy::None,
+            )
+        });
+        StoredTextResult::Err {
+            message: error.message,
+            diagnostics_json,
+        }
+    }
+}
+
+/// Request metadata identifying one helper-service call in a diagnostics
+/// report (`generateAuxFiles`, `expandDSP`, ...).
+fn service_diagnostics_request(mode: &str, args: &str) -> DiagnosticsRequestMetadata {
+    DiagnosticsRequestMetadata {
+        mode: Some(mode.to_owned()),
+        backend: None,
+        normalized_options: args.split_whitespace().map(str::to_owned).collect(),
+    }
 }
 
 /// Registry for compile result handles exposed to the host.
@@ -481,14 +530,14 @@ fn error_diagnostics_result(handle: u32) -> StoredTextResult {
     with_result(handle, |result| match result {
         Some(StoredCompileResult::Err(failure)) => match failure.render_complete_json() {
             Some(json) => StoredTextResult::Ok(json),
-            None => StoredTextResult::Err(
+            None => StoredTextResult::err(
                 "compile result has no structured compiler diagnostics".to_owned(),
             ),
         },
         Some(StoredCompileResult::Ok(_)) => {
-            StoredTextResult::Err("successful compile result has no error diagnostics".to_owned())
+            StoredTextResult::err("successful compile result has no error diagnostics")
         }
-        None => StoredTextResult::Err("unknown compile result handle".to_owned()),
+        None => StoredTextResult::err("unknown compile result handle"),
     })
 }
 
@@ -503,16 +552,17 @@ fn success_diagnostics_result(handle: u32) -> StoredTextResult {
             ))
         }
         Some(StoredCompileResult::Err(_)) => {
-            StoredTextResult::Err("failed compile result has no success diagnostics".to_owned())
+            StoredTextResult::err("failed compile result has no success diagnostics")
         }
-        None => StoredTextResult::Err("unknown compile result handle".to_owned()),
+        None => StoredTextResult::err("unknown compile result handle"),
     })
 }
 
 /// Read the UTF-8 payload pointer for one stored text result.
 fn text_result_ptr(handle: u32) -> *const u8 {
     with_text_result(handle, |result| match result {
-        Some(StoredTextResult::Ok(text)) | Some(StoredTextResult::Err(text)) => text.as_ptr(),
+        Some(StoredTextResult::Ok(text)) => text.as_ptr(),
+        Some(StoredTextResult::Err { message, .. }) => message.as_ptr(),
         None => std::ptr::null(),
     })
 }
@@ -520,7 +570,8 @@ fn text_result_ptr(handle: u32) -> *const u8 {
 /// Read the UTF-8 payload length for one stored text result.
 fn text_result_len(handle: u32) -> usize {
     with_text_result(handle, |result| match result {
-        Some(StoredTextResult::Ok(text)) | Some(StoredTextResult::Err(text)) => text.len(),
+        Some(StoredTextResult::Ok(text)) => text.len(),
+        Some(StoredTextResult::Err { message, .. }) => message.len(),
         None => 0,
     })
 }
@@ -734,12 +785,12 @@ pub unsafe extern "C" fn faust_wasm_get_info(what_ptr: *const u8, what_len: usiz
     let result = unsafe {
         let what = match decode_utf8_arg(what_ptr, what_len, "what") {
             Ok(what) => what,
-            Err(error) => return store_text_result(StoredTextResult::Err(error)),
+            Err(error) => return store_text_result(StoredTextResult::err(error)),
         };
         let compiler = Compiler::new();
         match compiler.get_faustwasm_info(what) {
             Ok(text) => StoredTextResult::Ok(text),
-            Err(error) => StoredTextResult::Err(error.to_string()),
+            Err(error) => StoredTextResult::err(error.to_string()),
         }
     };
     store_text_result(result)
@@ -766,15 +817,15 @@ pub unsafe extern "C" fn faust_wasm_expand_dsp(
     let result = unsafe {
         let name = match decode_utf8_arg(name_ptr, name_len, "name") {
             Ok(name) => name,
-            Err(error) => return store_text_result(StoredTextResult::Err(error)),
+            Err(error) => return store_text_result(StoredTextResult::err(error)),
         };
         let source = match decode_utf8_arg(source_ptr, source_len, "source") {
             Ok(source) => source,
-            Err(error) => return store_text_result(StoredTextResult::Err(error)),
+            Err(error) => return store_text_result(StoredTextResult::err(error)),
         };
         let args = match decode_utf8_arg(args_ptr, args_len, "args") {
             Ok(args) => args,
-            Err(error) => return store_text_result(StoredTextResult::Err(error)),
+            Err(error) => return store_text_result(StoredTextResult::err(error)),
         };
         let compiler = Compiler::new();
         match compiler.expand_dsp(&compiler::ExpandDspRequest {
@@ -783,7 +834,10 @@ pub unsafe extern "C" fn faust_wasm_expand_dsp(
             args: args.to_owned(),
         }) {
             Ok(text) => StoredTextResult::Ok(text),
-            Err(error) => StoredTextResult::Err(error.to_string()),
+            Err(error) => StoredTextResult::from_service_error(
+                error,
+                service_diagnostics_request("expandDSP", args),
+            ),
         }
     };
     store_text_result(result)
@@ -1021,15 +1075,15 @@ pub unsafe extern "C" fn faust_wasm_generate_aux_files_json(
     let result = unsafe {
         let name = match decode_utf8_arg(name_ptr, name_len, "name") {
             Ok(name) => name,
-            Err(error) => return store_text_result(StoredTextResult::Err(error)),
+            Err(error) => return store_text_result(StoredTextResult::err(error)),
         };
         let source = match decode_utf8_arg(source_ptr, source_len, "source") {
             Ok(source) => source,
-            Err(error) => return store_text_result(StoredTextResult::Err(error)),
+            Err(error) => return store_text_result(StoredTextResult::err(error)),
         };
         let args = match decode_utf8_arg(args_ptr, args_len, "args") {
             Ok(args) => args,
-            Err(error) => return store_text_result(StoredTextResult::Err(error)),
+            Err(error) => return store_text_result(StoredTextResult::err(error)),
         };
         let argv = split_faustwasm_args(args);
         let compiler = compiler_with_process_name_from_argv(&argv);
@@ -1050,7 +1104,10 @@ pub unsafe extern "C" fn faust_wasm_generate_aux_files_json(
                     .collect();
                 StoredTextResult::Ok(artifacts_to_json(&wasm_artifacts))
             }
-            Err(error) => StoredTextResult::Err(error.to_string()),
+            Err(error) => StoredTextResult::from_service_error(
+                error,
+                service_diagnostics_request("generateAuxFiles", args),
+            ),
         }
     };
     store_text_result(result)
@@ -1076,6 +1133,41 @@ pub extern "C" fn faust_wasm_text_result_ptr(handle: u32) -> *const u8 {
 #[unsafe(no_mangle)]
 pub extern "C" fn faust_wasm_text_result_len(handle: u32) -> usize {
     text_result_len(handle)
+}
+
+/// Returns the pointer to the complete diagnostics-v2 JSON report retained by
+/// one **error** text result.
+///
+/// Null when the handle is unknown, the result is successful, or the failure
+/// carried no typed compiler diagnostics (transport/argument errors) — in
+/// those cases the compatibility message from
+/// [`faust_wasm_text_result_ptr`] is all there is. Like the compile-result
+/// query [`faust_wasm_result_get_error_diagnostics`], this has no
+/// presentation parameter: every retained diagnostic field is serialized and
+/// the host derives smaller views locally.
+#[unsafe(no_mangle)]
+pub extern "C" fn faust_wasm_text_result_diagnostics_ptr(handle: u32) -> *const u8 {
+    with_text_result(handle, |result| match result {
+        Some(StoredTextResult::Err {
+            diagnostics_json: Some(json),
+            ..
+        }) => json.as_ptr(),
+        _ => std::ptr::null(),
+    })
+}
+
+/// Returns the byte length of the diagnostics-v2 JSON report retained by one
+/// error text result, or `0` when there is none (see
+/// [`faust_wasm_text_result_diagnostics_ptr`]).
+#[unsafe(no_mangle)]
+pub extern "C" fn faust_wasm_text_result_diagnostics_len(handle: u32) -> usize {
+    with_text_result(handle, |result| match result {
+        Some(StoredTextResult::Err {
+            diagnostics_json: Some(json),
+            ..
+        }) => json.len(),
+        _ => 0,
+    })
 }
 
 /// Releases a stored text result handle and the owned payload behind it.
@@ -1496,6 +1588,79 @@ mod tests {
         };
         super::faust_wasm_text_result_free(handle);
         (is_ok, text)
+    }
+
+    /// Helper: like [`call_generate_aux_files_json`] but also reads the
+    /// retained diagnostics-v2 report before releasing the handle.
+    fn call_generate_aux_files_json_with_diagnostics(
+        name: &str,
+        source: &str,
+        args: &str,
+    ) -> (u32, String, Option<String>) {
+        let handle = unsafe {
+            super::faust_wasm_generate_aux_files_json(
+                name.as_ptr(),
+                name.len(),
+                source.as_ptr(),
+                source.len(),
+                args.as_ptr(),
+                args.len(),
+            )
+        };
+        let is_ok = super::faust_wasm_text_result_is_ok(handle);
+        let text = unsafe {
+            let ptr = super::faust_wasm_text_result_ptr(handle);
+            let len = super::faust_wasm_text_result_len(handle);
+            std::str::from_utf8(std::slice::from_raw_parts(ptr, len))
+                .expect("result must be UTF-8")
+                .to_owned()
+        };
+        let diag_len = super::faust_wasm_text_result_diagnostics_len(handle);
+        let diagnostics = if diag_len == 0 {
+            assert!(super::faust_wasm_text_result_diagnostics_ptr(handle).is_null());
+            None
+        } else {
+            let ptr = super::faust_wasm_text_result_diagnostics_ptr(handle);
+            Some(unsafe {
+                std::str::from_utf8(std::slice::from_raw_parts(ptr, diag_len))
+                    .expect("diagnostics must be UTF-8")
+                    .to_owned()
+            })
+        };
+        super::faust_wasm_text_result_free(handle);
+        (is_ok, text, diagnostics)
+    }
+
+    #[test]
+    fn generate_aux_files_json_failure_retains_structured_diagnostics() {
+        // Misspelled identifier: the classic FRS-EVAL-0002 case from the
+        // error-model document — the host must receive the complete
+        // diagnostics-v2 report, not only the flattened message.
+        let (is_ok, text, diagnostics) = call_generate_aux_files_json_with_diagnostics(
+            "broken",
+            "cutoff = 1000;\nprocess = _ * cutof;\n",
+            "-lang asc -cn BrokenDsp --ec --os -o /broken.out.ts",
+        );
+        assert_eq!(is_ok, 0, "compilation must fail: {text}");
+        assert!(text.contains("cutof"), "compatibility message kept: {text}");
+        let json = diagnostics.expect("compiler failure must retain diagnostics");
+        assert!(json.contains(r#""schema_version": 2"#), "{json}");
+        assert!(json.contains("FRS-EVAL-0002"), "{json}");
+        assert!(json.contains(r#""category": "user_code""#), "{json}");
+        assert!(json.contains(r#""status": "failed""#), "{json}");
+        // The near-name suggestion travels as typed data.
+        assert!(json.contains("cutoff"), "{json}");
+    }
+
+    #[test]
+    fn generate_aux_files_json_success_has_no_diagnostics_payload() {
+        let (is_ok, _text, diagnostics) = call_generate_aux_files_json_with_diagnostics(
+            "fine",
+            "process = _;",
+            "-lang asc -cn FineDsp -o /fine.out.ts",
+        );
+        assert_eq!(is_ok, 1);
+        assert!(diagnostics.is_none());
     }
 
     #[test]

--- a/crates/wasm-ffi/src/lib.rs
+++ b/crates/wasm-ffi/src/lib.rs
@@ -141,11 +141,31 @@ impl StoredTextResult {
 
 /// Request metadata identifying one helper-service call in a diagnostics
 /// report (`generateAuxFiles`, `expandDSP`, ...).
+///
+/// Transport-only arguments are sanitized: a `--virtual-source
+/// <name>=<base64>` value keeps only the source name — the payload is the
+/// complete source text, which must not leak into the report (the report's
+/// own `sources` section is governed by [`SourceTextPolicy`], and inlining
+/// base64 here would both bypass that policy and bloat the payload).
 fn service_diagnostics_request(mode: &str, args: &str) -> DiagnosticsRequestMetadata {
+    let mut normalized_options: Vec<String> = Vec::new();
+    let mut elide_next_value = false;
+    for token in args.split_whitespace() {
+        if elide_next_value {
+            elide_next_value = false;
+            let name = token.split('=').next().unwrap_or(token);
+            normalized_options.push(format!("{name}=<elided>"));
+            continue;
+        }
+        if token == "--virtual-source" {
+            elide_next_value = true;
+        }
+        normalized_options.push(token.to_owned());
+    }
     DiagnosticsRequestMetadata {
         mode: Some(mode.to_owned()),
         backend: None,
-        normalized_options: args.split_whitespace().map(str::to_owned).collect(),
+        normalized_options,
     }
 }
 
@@ -1661,6 +1681,123 @@ mod tests {
         );
         assert_eq!(is_ok, 1);
         assert!(diagnostics.is_none());
+    }
+
+    #[test]
+    fn diagnostics_report_parses_structurally_with_typed_fixes() {
+        let (is_ok, _text, diagnostics) = call_generate_aux_files_json_with_diagnostics(
+            "broken",
+            "cutoff = 1000;\nprocess = _ * cutof;\n",
+            "-lang asc -cn BrokenDsp -o /broken.out.ts",
+        );
+        assert_eq!(is_ok, 0);
+        let payload: serde_json::Value =
+            serde_json::from_str(&diagnostics.expect("diagnostics retained"))
+                .expect("diagnostics report must be valid JSON");
+        assert_eq!(payload["schema_version"], 2);
+        assert_eq!(payload["status"], "failed");
+        assert_eq!(payload["request"]["mode"], "generateAuxFiles");
+        let diagnostic = &payload["diagnostics"][0];
+        assert_eq!(diagnostic["code"], "FRS-EVAL-0002");
+        assert_eq!(diagnostic["category"], "user_code");
+        assert_eq!(diagnostic["severity"], "error");
+        // The primary label carries a resolvable span.
+        let label = &diagnostic["labels"][0];
+        assert_eq!(label["style"], "primary");
+        assert!(label["range"]["start"].is_number());
+        assert_eq!(label["compatibility_span"]["line"], 2);
+        // The rename fix travels typed, with its applicability promise.
+        let fix = &diagnostic["fixes"][0];
+        assert_eq!(fix["applicability"], "maybe_incorrect");
+        assert_eq!(
+            fix["edits"][0]["replacement"], "cutoff",
+            "typed edit expected: {fix}"
+        );
+    }
+
+    #[test]
+    fn diagnostics_report_elides_virtual_source_payloads() {
+        // The sibling source travels as `--virtual-source name=<base64>`;
+        // neither the source text nor its base64 encoding may appear in the
+        // diagnostics report (SourceTextPolicy::None governs source echoing).
+        let marker = "SECRET_HELPER_CONTENT_98765";
+        let helper = format!("wet = 0.5; // {marker}\n");
+        let helper_b64 = super::base64_encode(helper.as_bytes());
+        let args = format!(
+            "-lang asc -cn BrokenDsp --virtual-source helper.dsp={helper_b64} -o /broken.out.ts"
+        );
+        let (is_ok, _text, diagnostics) = call_generate_aux_files_json_with_diagnostics(
+            "broken",
+            "h = library(\"helper.dsp\");\nprocess = _ * undefined_symbol;\n",
+            &args,
+        );
+        assert_eq!(is_ok, 0);
+        let json = diagnostics.expect("compiler failure must retain diagnostics");
+        assert!(!json.contains(marker), "source text leaked: {json}");
+        assert!(!json.contains(&helper_b64), "base64 payload leaked");
+        assert!(
+            json.contains("helper.dsp=<elided>"),
+            "virtual-source name retained as metadata: {json}"
+        );
+    }
+
+    #[test]
+    fn expand_dsp_failure_retains_structured_diagnostics() {
+        let source = "process = _ * cutof;";
+        let args = "";
+        let handle = unsafe {
+            super::faust_wasm_expand_dsp(
+                "broken".as_ptr(),
+                "broken".len(),
+                source.as_ptr(),
+                source.len(),
+                args.as_ptr(),
+                args.len(),
+            )
+        };
+        assert_eq!(super::faust_wasm_text_result_is_ok(handle), 0);
+        let diag_len = super::faust_wasm_text_result_diagnostics_len(handle);
+        assert!(diag_len > 0, "expandDSP must retain compiler diagnostics");
+        let json = unsafe {
+            let ptr = super::faust_wasm_text_result_diagnostics_ptr(handle);
+            std::str::from_utf8(std::slice::from_raw_parts(ptr, diag_len))
+                .expect("diagnostics must be UTF-8")
+                .to_owned()
+        };
+        assert!(json.contains("FRS-EVAL-0002"), "{json}");
+        assert!(json.contains(r#""mode": "expandDSP""#), "{json}");
+        super::faust_wasm_text_result_free(handle);
+    }
+
+    #[test]
+    fn argument_failures_have_no_diagnostics_payload() {
+        // get_info with an unknown key: an InvalidArgument service error with
+        // no compiler diagnostic behind it.
+        let what = "bogus-info-key";
+        let handle = unsafe { super::faust_wasm_get_info(what.as_ptr(), what.len()) };
+        assert_eq!(super::faust_wasm_text_result_is_ok(handle), 0);
+        assert_eq!(super::faust_wasm_text_result_diagnostics_len(handle), 0);
+        assert!(super::faust_wasm_text_result_diagnostics_ptr(handle).is_null());
+        super::faust_wasm_text_result_free(handle);
+    }
+
+    #[test]
+    fn unknown_and_freed_handles_have_no_diagnostics_payload() {
+        // Never-issued handle.
+        assert!(super::faust_wasm_text_result_diagnostics_ptr(0xDEAD_BEEF).is_null());
+        assert_eq!(
+            super::faust_wasm_text_result_diagnostics_len(0xDEAD_BEEF),
+            0
+        );
+
+        // Freed handle: reading after release must yield the same nulls.
+        let (handle, _) = {
+            let handle = store_text_result(super::StoredTextResult::err("gone"));
+            (handle, ())
+        };
+        super::faust_wasm_text_result_free(handle);
+        assert!(super::faust_wasm_text_result_diagnostics_ptr(handle).is_null());
+        assert_eq!(super::faust_wasm_text_result_diagnostics_len(handle), 0);
     }
 
     #[test]

--- a/crates/xtask/src/tests.rs
+++ b/crates/xtask/src/tests.rs
@@ -418,6 +418,8 @@ fn verify_wasm_ffi_exports_accepts_expected_surface() {
               (func (export "faust_wasm_text_result_is_ok"))
               (func (export "faust_wasm_text_result_ptr"))
               (func (export "faust_wasm_text_result_len"))
+              (func (export "faust_wasm_text_result_diagnostics_ptr"))
+              (func (export "faust_wasm_text_result_diagnostics_len"))
               (func (export "faust_wasm_text_result_free"))
             )
             "#,

--- a/crates/xtask/src/wasm.rs
+++ b/crates/xtask/src/wasm.rs
@@ -152,6 +152,8 @@ pub(crate) fn required_wasm_ffi_exports() -> &'static [&'static str] {
         "faust_wasm_text_result_is_ok",
         "faust_wasm_text_result_ptr",
         "faust_wasm_text_result_len",
+        "faust_wasm_text_result_diagnostics_ptr",
+        "faust_wasm_text_result_diagnostics_len",
         "faust_wasm_text_result_free",
     ]
 }

--- a/porting/journal/2026-07-30.md
+++ b/porting/journal/2026-07-30.md
@@ -427,3 +427,28 @@ field names carry the units, which bare `(String, u64, u64)` did not.
 
 Validation: `cargo test -p xtask` (83 tests); clippy `-D warnings`; fmt;
 `compile-budget-check` green on three consecutive runs, all 12 cases.
+
+## Helper-service diagnostics: review follow-ups (PR #14)
+
+Review points addressed on the branch:
+
+- `service_diagnostics_request` sanitizes transport-only arguments: a
+  `--virtual-source <name>=<base64>` value keeps only `<name>=<elided>` in
+  `normalized_options` — the payload is the complete source text, which
+  must not bypass `SourceTextPolicy::None` or bloat the report. A
+  regression test proves neither the source text nor its base64 encoding
+  appears in the diagnostics JSON.
+- The two new exports joined `required_wasm_ffi_exports()` and the WAT
+  guard fixture, so CI detects accidental removal.
+- Tests now also cover `expandDSP` failures (report present, `mode:
+  "expandDSP"`), argument failures (no payload), unknown/freed handles
+  (null/0), structural JSON parsing with typed `fixes`/`applicability`.
+- Source-compatibility note: `FaustwasmServiceError` gained the public
+  field `diagnostics: Option<DiagnosticBundle>`. Any downstream code
+  constructing the struct literally must add the field; the constructors
+  (`unsupported`, `invalid_argument`) are unchanged in signature. The
+  `unsupported` rustdoc no longer claims every compiler failure maps
+  through it — `CompilerError` sources go through `compile_failure`.
+- Host-adapter status recorded in `crates/wasm-ffi/README.md`:
+  WebAssembly Music consumes the new exports; the `faustwasm` TypeScript
+  adapter does not read them yet (tracked follow-up).


### PR DESCRIPTION
## Summary

Follow-up to the WASM structured-diagnostics integration: the compile-result handles already serve the complete diagnostics-v2 report, but the **helper-service surface** (`generateAuxFiles`, `expandDSP` — the path every `-lang asc` host drives) still flattened `CompilerError` to one string at the `FaustwasmServiceError` boundary:

```text
ok = 0 | message: evaluation failed for broken: undefined symbol `cutof`
```

## Changes

- `FaustwasmServiceError` gains `diagnostics: Option<DiagnosticBundle>`, populated by a new `compile_failure` constructor at every `CompilerError` mapping site in `service.rs` (cpp/c/wasm/json/svg-front-end, the asc signals + lowering path, and `expand_dsp`). Transport/argument failures stay `None`.
- The wasm-ffi text-result registry stores an owned diagnostics-v2 report next to the compatibility message, rendered with the same no-presentation-parameter contract as `faust_wasm_result_get_error_diagnostics`. Request metadata identifies the service call (`mode: "generateAuxFiles"` / `"expandDSP"` + the raw options).
- Two new exports: `faust_wasm_text_result_diagnostics_ptr/len` — null/0 on success or when no typed diagnostics exist, so **existing hosts keep working unchanged**.

## Verified

Node run against the rebuilt module, misspelled-identifier probe through `generateAuxFiles`:

```text
code: FRS-EVAL-0002 | category: user_code | stage: eval
primary label: {"col":25,"end_col":30,"end_line":3,"file":"broken","line":3}
facts.suggested_symbols: {"type":"string_list","value":["cutoff"]}
fixes: [{"title":"rename to `cutoff`","applicability":"maybe_incorrect"}]
```

- wasm-ffi tests lock the failure payload (code/category/typed suggestion) and the empty success payload; compiler + wasm-ffi suites green, clippy 0, fmt clean.

## Motivation

WebAssembly Music's Faust editor and its studio agent compile through `generateAuxFiles` — this is the missing link for feeding the enriched errors to the LLM writing DSP code there (per the error-model doc §5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)