### PR TITLE
Bound provenance evidence to fix the dx7-class compile blow-up

### DIFF
--- a/crates/propagate/src/lib.rs
+++ b/crates/propagate/src/lib.rs
@@ -227,10 +227,23 @@ impl Default for SignalOrigins {
 }
 
 impl SignalOrigins {
+    /// Maximum Box candidates retained per signal.
+    ///
+    /// Origins are bounded diagnostic evidence, not an exhaustive occurrence
+    /// index: hash-consed signals shared by many boxes would otherwise
+    /// accumulate unbounded lists, and the per-pass `inherit_forest` unions
+    /// would turn preparation super-quadratic on large programs (dx7-class
+    /// DSPs regressed from ~1s to minutes). Diagnostic-time occurrence
+    /// choice only ever consults the leading candidates.
+    pub const MAX_ORIGINS_PER_SIGNAL: usize = 8;
+
     /// Records that `signal` was produced while propagating `box_node`.
+    ///
+    /// Retains at most [`Self::MAX_ORIGINS_PER_SIGNAL`] candidates per
+    /// signal, in first-recorded order.
     pub fn record(&mut self, signal: SigId, box_node: BoxId) {
         let origins = self.by_signal.entry(signal).or_default();
-        if !origins.contains(&box_node) {
+        if origins.len() < Self::MAX_ORIGINS_PER_SIGNAL && !origins.contains(&box_node) {
             origins.push(box_node);
         }
     }

--- a/crates/transform/src/signal_fir/origins.rs
+++ b/crates/transform/src/signal_fir/origins.rs
@@ -40,7 +40,18 @@ impl FirOrigins {
         Self::default()
     }
 
+    /// Maximum Signal derivations retained per FIR node.
+    ///
+    /// Like [`SignalOrigins::MAX_ORIGINS_PER_SIGNAL`], this keeps the tables
+    /// bounded diagnostic evidence: `derive_reachable` unions descendant
+    /// derivations into every reachable parent, so unbounded per-node lists
+    /// would grow with program size and make the walk super-quadratic.
+    pub const MAX_SIGNALS_PER_NODE: usize = 8;
+
     /// Records one prepared Signal as a direct producer of `fir`.
+    ///
+    /// Retains at most [`Self::MAX_SIGNALS_PER_NODE`] derivations per node,
+    /// in Signal-id order.
     pub fn record_signal(&mut self, fir: FirId, signal: SigId, signal_origins: &SignalOrigins) {
         let boxes = signal_origins.origins_for(signal).to_vec();
         let entries = self.by_fir.entry(fir).or_default();
@@ -50,7 +61,7 @@ impl FirOrigins {
                     existing.boxes.push(origin);
                 }
             }
-        } else {
+        } else if entries.len() < Self::MAX_SIGNALS_PER_NODE {
             entries.push(FirSignalOrigin { signal, boxes });
             entries.sort_by_key(|entry| entry.signal.as_u32());
         }
@@ -138,7 +149,7 @@ fn merge_origin(entries: &mut Vec<FirSignalOrigin>, origin: &FirSignalOrigin) {
                 existing.boxes.push(box_origin);
             }
         }
-    } else {
+    } else if entries.len() < FirOrigins::MAX_SIGNALS_PER_NODE {
         entries.push(origin.clone());
         entries.sort_by_key(|entry| entry.signal.as_u32());
     }

--- a/porting/journal/2026-07-30.md
+++ b/porting/journal/2026-07-30.md
@@ -225,3 +225,29 @@ compatibility, lifecycle, testing, and documentation gates; they do not change
 compiler behaviour or expose a new FFI API yet.
 
 Validation: Markdown structure and whitespace checks; staged-diff check.
+
+## Provenance tables must stay bounded (dx7 regression)
+
+Wiring the enriched errors into WebAssembly Music surfaced a performance
+regression on main: `dx.algorithm(5)` (dx7.lib), which compiled in about a
+second, now ran past 90 seconds in `--check`. `git bisect` over the 75
+commits since the last-known-fast base landed on `3f42babc` ("Preserve
+diagnostics through FIR and backends"), and `sample` put the time in
+`propagate::SignalOrigins::inherit`.
+
+The mechanism: the provenance machinery predates that commit but ran with
+empty tables (the facade did not pass propagated origins yet), so the
+per-pass `inherit_forest` walks were no-ops. Once real origins flow in,
+every preparation pass unions each node's descendants' origin lists up the
+DAG — hash-consed signals shared by many boxes make leaf lists large, so
+the upper forest accumulates unbounded lists with linear-scan dedup:
+super-quadratic in program size.
+
+Fix: cap the evidence, which the design already described as "bounded" —
+`SignalOrigins::MAX_ORIGINS_PER_SIGNAL = 8` Box candidates per signal and
+`FirOrigins::MAX_SIGNALS_PER_NODE = 8` Signal derivations per FIR node,
+first-recorded order retained. dx7 `--check` returns to 2.2s; diagnostics
+suites (cli_diagnostics_channel, diagnostic_errors,
+machine_applicable_fixes), workspace tests, clippy, and golden all stay
+green. Diagnostic-time occurrence choice only ever consulted the leading
+candidates, so bounded lists lose no blame precision in practice.


### PR DESCRIPTION
## Symptom

`dx.algorithm(5)` (dx7.lib) compiled in ~1s before the diagnostics provenance work and now runs past 90s in `--check` (native CLI and wasm module alike — found while wiring the enriched errors into WebAssembly Music).

## Root cause

`git bisect` over the 75 commits since the last-known-fast base lands on 3f42babc (*Preserve diagnostics through FIR and backends*); `sample` puts the time in `propagate::SignalOrigins::inherit`.

The provenance machinery predates that commit but ran with **empty tables** (the facade didn't pass propagated origins yet), so the per-pass `inherit_forest` walks were no-ops. Once real origins flow in, every preparation pass unions each node's descendants' origin lists up the DAG. Hash-consed signals shared by many boxes make leaf lists large, so the upper forest accumulates unbounded candidate lists with linear-scan dedup — super-quadratic in program size. (Same failure family as the `dump_fir` indentation blow-up fixed in #9.)

## Fix

Cap the evidence where it grows — the design already describes these tables as "bounded debug evidence":

- `SignalOrigins::MAX_ORIGINS_PER_SIGNAL = 8` Box candidates per signal (`record`)
- `FirOrigins::MAX_SIGNALS_PER_NODE = 8` Signal derivations per FIR node (`record_signal` / `merge_origin`)

First-recorded order is retained, so the leading candidates — the only ones diagnostic-time occurrence choice consults — are unchanged.

## Measurements & gates

- dx7 `--check`: **>90s (timeout) → 2.2s**.
- `cli_diagnostics_channel`, `diagnostic_errors`, `machine_applicable_fixes`: green (no diagnostic quality change on the negative corpus).
- Workspace tests, clippy 0, fmt clean, golden corpus OK.

If you'd prefer a different bound or a lazy diagnostic-time derivation instead of eager capped unions, happy to adjust — the cap is the minimal change that restores the documented contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)